### PR TITLE
Back button on add listing form malfunctioning #4951

### DIFF
--- a/includes/views/submit_listing.php
+++ b/includes/views/submit_listing.php
@@ -714,7 +714,8 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 		}
 
 		$section['flags'][]         = $section['state'];
-		$section['prev_section']    = $previous_section ? $previous_section : $this->current_section; // Set previous section to current section if none is set.
+        // If there is no previous section, we should not set it to the next section. It should be blank by default, only allowing next.
+		$section['prev_section']    = $previous_section ? $previous_section : '';
 		$section['next_section']    = $this->find_next_section( $section['id'] );
 
 		$same_page = array_intersect( array( 'has-error', 'has-message' ), $this->sections[ $section['id'] ]['flags'] );

--- a/includes/views/submit_listing.php
+++ b/includes/views/submit_listing.php
@@ -714,7 +714,7 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 		}
 
 		$section['flags'][]         = $section['state'];
-		$section['prev_section']    = $previous_section ? $previous_section : $this->current_section; //Set previous section to current section if none is set
+		$section['prev_section']    = $previous_section ? $previous_section : $this->current_section; // Set previous section to current section if none is set.
 		$section['next_section']    = $this->find_next_section( $section['id'] );
 
 		$same_page = array_intersect( array( 'has-error', 'has-message' ), $this->sections[ $section['id'] ]['flags'] );

--- a/includes/views/submit_listing.php
+++ b/includes/views/submit_listing.php
@@ -713,9 +713,9 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 			$this->maybe_remove_images_section();
 		}
 
-		$section['flags'][]      = $section['state'];
-		$section['prev_section'] = $previous_section ? $previous_section : $this->find_next_section( $section['id'] );
-		$section['next_section'] = $this->find_next_section( $section['id'] );
+		$section['flags'][]         = $section['state'];
+		$section['prev_section']    = $previous_section ? $previous_section : $this->current_section; //Set previous section to current section if none is set
+		$section['next_section']    = $this->find_next_section( $section['id'] );
 
 		$same_page = array_intersect( array( 'has-error', 'has-message' ), $this->sections[ $section['id'] ]['flags'] );
 		if ( ! $next_section && ! empty( $same_page ) ) {


### PR DESCRIPTION
This is related to https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4951

The back button would show on default when there is no previous section, yet the back button is only meant to show when there is something to go back to