### PR TITLE
Setting button text update

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -877,7 +877,7 @@ final class WPBDP__Settings__Bootstrap {
             array(
                 'id'      => 'show-directory-button',
                 'type'    => 'checkbox',
-                'name'    => _x( 'Show the "Directory" button.', 'settings', 'business-directory-plugin' ),
+                'name'    => _x( 'Show the "Directory" and "Return to Directory" button.', 'settings', 'business-directory-plugin' ),
                 'default' => true,
                 'group'   => 'display_options',
             )

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -877,7 +877,8 @@ final class WPBDP__Settings__Bootstrap {
             array(
                 'id'      => 'show-directory-button',
                 'type'    => 'checkbox',
-                'name'    => _x( 'Show the "Directory" and "Return to Directory" button.', 'settings', 'business-directory-plugin' ),
+                'name'    => _x( 'Show the "Directory" button.', 'settings', 'business-directory-plugin' ),
+                'desc'    => __( 'Show the "Directory" and "Return to Directory" button.', 'business-directory-plugin' ),
                 'default' => true,
                 'group'   => 'display_options',
             )


### PR DESCRIPTION
This addresses the issue raised here https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4952 . The setting text has been updated to : `Show the "Directory" and "Return to Directory" button.`