### PR TITLE
Listing statistics feature

### DIFF
--- a/includes/admin/class-admin-listings.php
+++ b/includes/admin/class-admin-listings.php
@@ -316,8 +316,11 @@ class WPBDP_Admin_Listings {
         }
     }
 
+    /**
+     * View column
+     */
     public function listing_column_views( $post_id ) {
-        $statistics = new WPBDP_Listing_Statistic();
+        $statistics = WPBDP_Listing_Statistic::instance();
         echo $statistics->count_views( $post_id );
     }
 

--- a/includes/admin/class-admin-listings.php
+++ b/includes/admin/class-admin-listings.php
@@ -270,9 +270,13 @@ class WPBDP_Admin_Listings {
             $new_columns[ $c_key ] = $c_label;
         }
 
-        // Attributes goes last.
-        $new_columns['attributes'] = __( 'Attributes', 'business-directory-plugin' );
+        //Views for statistics
+        if ( wpbdp_get_option( 'listings-sortbar-enabled' ) ) {
+            $new_columns['views']   = __( 'Views', 'business-directory-plugin' );
+        }
 
+        // Attributes goes last.
+        $new_columns['attributes']  = __( 'Attributes', 'business-directory-plugin' );
         $new_columns = apply_filters( 'wpbdp_admin_directory_columns', $new_columns );
         return $new_columns;
     }

--- a/includes/admin/class-admin-listings.php
+++ b/includes/admin/class-admin-listings.php
@@ -316,6 +316,11 @@ class WPBDP_Admin_Listings {
         }
     }
 
+    public function listing_column_views( $post_id ) {
+        $statistics = new WPBDP_Listing_Statistic();
+        echo $statistics->count_views( $post_id );
+    }
+
     public function listing_column_attributes( $post_id ) {
         $listing = WPBDP_Listing::get( $post_id );
         $plan    = $listing->get_fee_plan();

--- a/includes/admin/class-admin-listings.php
+++ b/includes/admin/class-admin-listings.php
@@ -271,7 +271,7 @@ class WPBDP_Admin_Listings {
         }
 
         //Views for statistics
-        if ( wpbdp_get_option( 'listings-sortbar-enabled' ) ) {
+        if ( wpbdp_get_option( 'listings-stats-enabled' ) ) {
             $new_columns['views']   = __( 'Views', 'business-directory-plugin' );
         }
 

--- a/includes/admin/class-admin-listings.php
+++ b/includes/admin/class-admin-listings.php
@@ -320,7 +320,7 @@ class WPBDP_Admin_Listings {
      * View column
      */
     public function listing_column_views( $post_id ) {
-        $statistics = WPBDP_Listing_Statistic::instance();
+        $statistics = WPBDP_Listing_Statistic::get_instance();
         echo $statistics->count_views( $post_id );
     }
 

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -437,6 +437,8 @@ final class WPBDP__Settings__Bootstrap {
 
         wpbdp_register_settings_group( 'listings/sorting', __( 'Sorting', 'business-directory-plugin' ), 'listings' );
 
+        wpbdp_register_settings_group( 'listings/stats', __( 'Statistics', 'business-directory-plugin' ), 'listings' );
+
         wpbdp_register_setting(
             array(
                 'id'      => 'listings-per-page',
@@ -765,6 +767,17 @@ final class WPBDP__Settings__Bootstrap {
                 'name'    => _x( 'Show only parent categories in category list?', 'settings', 'business-directory-plugin' ),
                 'default' => false,
                 'group'   => 'listings/post_category',
+            )
+        );
+
+        wpbdp_register_setting(
+            array(
+                'id'      => 'listings-sortbar-enabled',
+                'type'    => 'checkbox',
+                'name'    => _x( 'Enable statistics?', 'settings', 'business-directory-plugin' ),
+                'desc'    => _x( 'Enable usage tracking of your listings', 'settings', 'business-directory-plugin' ),
+                'default' => false,
+                'group'   => 'listings/stats',
             )
         );
 

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -770,17 +770,6 @@ final class WPBDP__Settings__Bootstrap {
             )
         );
 
-        wpbdp_register_setting(
-            array(
-                'id'      => 'listings-sortbar-enabled',
-                'type'    => 'checkbox',
-                'name'    => _x( 'Enable statistics?', 'settings', 'business-directory-plugin' ),
-                'desc'    => _x( 'Enable usage tracking of your listings', 'settings', 'business-directory-plugin' ),
-                'default' => false,
-                'group'   => 'listings/stats',
-            )
-        );
-
         $msg = _x( 'Fee Plan Custom Order can be changed under <a>Fee Plans</a>', 'admin settings', 'business-directory-plugin' );
         $msg = str_replace( '<a>', '<a href="' . esc_url( admin_url( 'admin.php?page=wpbdp-admin-fees' ) ) . '">', $msg );
         wpbdp_register_setting(
@@ -843,6 +832,28 @@ final class WPBDP__Settings__Bootstrap {
         );
 
 		WPBDP_Admin_Education::add_tip_in_settings( 'abc', 'listings/sorting' );
+
+        wpbdp_register_setting(
+            array(
+                'id'      => 'listings-stats-enabled',
+                'type'    => 'checkbox',
+                'name'    => _x( 'Enable statistics?', 'settings', 'business-directory-plugin' ),
+                'desc'    => _x( 'Enable usage tracking of your listings', 'settings', 'business-directory-plugin' ),
+                'default' => false,
+                'group'   => 'listings/stats',
+            )
+        );
+
+        wpbdp_register_setting(
+            array(
+                'id'      => 'listings-stats-admin-enabled',
+                'type'    => 'checkbox',
+                'name'    => _x( 'Track Admins?', 'settings', 'business-directory-plugin' ),
+                'desc'    => _x( 'Enable tracking of admin views to the count', 'settings', 'business-directory-plugin' ),
+                'default' => false,
+                'group'   => 'listings/stats',
+            )
+        );
     }
 
     private static function settings_appearance() {

--- a/includes/class-listing.php
+++ b/includes/class-listing.php
@@ -6,6 +6,8 @@
 require_once WPBDP_PATH . 'includes/class-payment.php';
 require_once WPBDP_PATH . 'includes/class-listing-subscription.php';
 require_once WPBDP_PATH . 'includes/helpers/class-listing-image.php';
+require_once WPBDP_PATH . 'includes/models/listing/class-listing-statistic.php';
+
 class WPBDP_Listing {
 
     private $id = 0;

--- a/includes/class-listing.php
+++ b/includes/class-listing.php
@@ -489,7 +489,8 @@ class WPBDP_Listing {
 		$status = apply_filters( 'wpbdp_delete_post_status', wpbdp_get_option( 'deleted-status' ) );
         $wpdb->update( $wpdb->posts, array( 'post_status' => $status ), array( 'ID' => $this->id ) );
         clean_post_cache( $this->id );
-
+        $statistics = WPBDP_Listing_Statistic::instance();
+        $statistics->delete_by_listing_id( $this->id );
         return true;
     }
 

--- a/includes/class-wpbdp.php
+++ b/includes/class-wpbdp.php
@@ -67,6 +67,8 @@ final class WPBDP {
 
         require_once WPBDP_INC . 'helpers/listing_flagging.php';
 
+        require_once WPBDP_INC . 'helpers/class-ip-helper.php';
+
         require_once WPBDP_INC . 'class-cpt-integration.php';
         require_once WPBDP_INC . 'class-listing-expiration.php';
         require_once WPBDP_INC . 'class-listing-email-notification.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1127,6 +1127,11 @@ function wpbdp_render_listing( $listing_id = null, $view = 'single', $echo = fal
         $html = WPBDP_Listing_Display_Helper::single();
     }
 
+    if ( $view === 'single' ) {
+        $post_id = get_post() ? get_the_ID() : '0';
+        wpbdp_save_listing_statistic( $listing_id, $post_id );
+    }
+
     if ( $echo ) {
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo $html;

--- a/includes/helpers/class-ip-helper.php
+++ b/includes/helpers/class-ip-helper.php
@@ -1,0 +1,154 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * IP Helper
+ */
+class WPBDP_IP_Helper {
+
+    /**
+	 * Validates that the IP that made the request is from cloudflare
+	 *
+	 * @param String $ip - the ip to check
+	 *
+	 * @return bool
+	 */
+	private static function _validate_cloudflare_ip( $ip ) {
+		$cloudflare_ips = array(
+			'199.27.128.0/21',
+			'173.245.48.0/20',
+			'103.21.244.0/22',
+			'103.22.200.0/22',
+			'103.31.4.0/22',
+			'141.101.64.0/18',
+			'108.162.192.0/18',
+			'190.93.240.0/20',
+			'188.114.96.0/20',
+			'197.234.240.0/22',
+			'198.41.128.0/17',
+			'162.158.0.0/15',
+			'104.16.0.0/12',
+		);
+		$is_cf_ip       = false;
+		foreach ( $cloudflare_ips as $cloudflare_ip ) {
+			if ( self::_cloudflare_ip_in_range( $ip, $cloudflare_ip ) ) {
+				$is_cf_ip = true;
+				break;
+			}
+		}
+
+		return $is_cf_ip;
+	}
+
+	/**
+	 * Check if the cloudflare IP is in range
+	 *
+	 * @param String $ip - the current IP
+	 * @param String $range - the allowed range of cloudflare ips
+	 *
+	 * @return bool
+	 */
+	private static function _cloudflare_ip_in_range( $ip, $range ) {
+		if ( strpos( $range, '/' ) === false ) {
+			$range .= '/32';
+		}
+
+		// $range is in IP/CIDR format eg 127.0.0.1/24
+		list( $range, $netmask ) = explode( '/', $range, 2 );
+		$range_decimal    = ip2long( $range );
+		$ip_decimal       = ip2long( $ip );
+		$wildcard_decimal = pow( 2, ( 32 - $netmask ) ) - 1;
+		$netmask_decimal  = ~$wildcard_decimal;
+
+		return ( ( $ip_decimal & $netmask_decimal ) === ( $range_decimal & $netmask_decimal ) );
+	}
+
+	/**
+	 * Check if there are any cloudflare headers in the request
+	 *
+	 * @return bool
+	 */
+	private static function _cloudflare_requests_check() {
+		$flag = true;
+
+		if ( ! isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+			$flag = false;
+		}
+		if ( ! isset( $_SERVER['HTTP_CF_IPCOUNTRY'] ) ) {
+			$flag = false;
+		}
+		if ( ! isset( $_SERVER['HTTP_CF_RAY'] ) ) {
+			$flag = false;
+		}
+		if ( ! isset( $_SERVER['HTTP_CF_VISITOR'] ) ) {
+			$flag = false;
+		}
+
+		return $flag;
+	}
+
+	/**
+	 * Check if the request is from cloudflare. If it is, we get the IP
+	 *
+	 * @return bool
+	 */
+	private static function is_cloudflare() {
+		if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+			$ip = $_SERVER['HTTP_CLIENT_IP'];
+		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		} else {
+			$ip = $_SERVER['REMOTE_ADDR'];
+		}
+		if ( isset( $ip ) ) {
+			$request_check = self::_cloudflare_requests_check();
+			if ( ! $request_check ) {
+				return false;
+			}
+
+			$ip_check = self::_validate_cloudflare_ip( $ip );
+
+			return $ip_check;
+		}
+
+		return false;
+	}
+
+	/**
+	 * A shorhand function to get user IP
+	 *
+	 * @return mixed|string
+	 */
+	public static function get_user_ip() {
+		$client  = isset( $_SERVER['HTTP_CLIENT_IP'] ) ? $_SERVER['HTTP_CLIENT_IP'] : null;
+		$forward = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : null;
+		$is_cf   = self::is_cloudflare(); //Check if request is from CloudFlare
+		if ( $is_cf ) {
+			$cf_ip = $_SERVER['HTTP_CF_CONNECTING_IP']; //We already make sure this is set in the checks
+			if ( filter_var( $cf_ip, FILTER_VALIDATE_IP ) ) {
+				return apply_filters( 'wpbdp_helper_user_ip', $cf_ip );
+			}
+		} else {
+			$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
+		}
+		$client_real = isset( $_SERVER['HTTP_X_REAL_IP'] ) ? $_SERVER['HTTP_X_REAL_IP'] : null;
+		$user_ip     = $remote;
+		if ( filter_var( $client, FILTER_VALIDATE_IP ) ) {
+			$user_ip = $client;
+		} elseif ( filter_var( $client_real, FILTER_VALIDATE_IP ) ) {
+			$user_ip = $client_real;
+		} elseif ( ! empty( $forward ) ) {
+			$forward = explode( ',', $forward );
+			$ip      = array_shift( $forward );
+			$ip      = trim( $ip );
+			if ( filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+				$user_ip = $ip;
+			}
+		}
+
+		return apply_filters( 'wpbdp_helper_user_ip', $user_ip );
+	}
+}

--- a/includes/helpers/class-ip-helper.php
+++ b/includes/helpers/class-ip-helper.php
@@ -74,15 +74,19 @@ class WPBDP_IP_Helper {
 	private static function _cloudflare_requests_check() {
 		$flag = true;
 
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
 			$flag = false;
 		}
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_SERVER['HTTP_CF_IPCOUNTRY'] ) ) {
 			$flag = false;
 		}
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_SERVER['HTTP_CF_RAY'] ) ) {
 			$flag = false;
 		}
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_SERVER['HTTP_CF_VISITOR'] ) ) {
 			$flag = false;
 		}
@@ -97,10 +101,13 @@ class WPBDP_IP_Helper {
 	 */
 	private static function is_cloudflare() {
 		if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$ip = $_SERVER['HTTP_CLIENT_IP'];
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
 		} else {
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$ip = $_SERVER['REMOTE_ADDR'];
 		}
 		if ( isset( $ip ) ) {
@@ -123,17 +130,22 @@ class WPBDP_IP_Helper {
 	 * @return mixed|string
 	 */
 	public static function get_user_ip() {
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$client  = isset( $_SERVER['HTTP_CLIENT_IP'] ) ? $_SERVER['HTTP_CLIENT_IP'] : null;
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$forward = isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : null;
 		$is_cf   = self::is_cloudflare(); //Check if request is from CloudFlare
 		if ( $is_cf ) {
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$cf_ip = $_SERVER['HTTP_CF_CONNECTING_IP']; //We already make sure this is set in the checks
 			if ( filter_var( $cf_ip, FILTER_VALIDATE_IP ) ) {
 				return apply_filters( 'wpbdp_helper_user_ip', $cf_ip );
 			}
 		} else {
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
 		}
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$client_real = isset( $_SERVER['HTTP_X_REAL_IP'] ) ? $_SERVER['HTTP_X_REAL_IP'] : null;
 		$user_ip     = $remote;
 		if ( filter_var( $client, FILTER_VALIDATE_IP ) ) {

--- a/includes/installer.php
+++ b/includes/installer.php
@@ -83,7 +83,7 @@ class WPBDP_Installer {
         global $wpdb;
 
         // https://core.trac.wordpress.org/ticket/33885.
-        $max_index_length 	= 191;
+        $max_index_length = 191;
 
         $schema = array();
 

--- a/includes/installer.php
+++ b/includes/installer.php
@@ -10,7 +10,7 @@ require_once ( WPBDP_PATH . 'includes/admin/upgrades/class-migration.php' );
  */
 class WPBDP_Installer {
 
-    const DB_VERSION = '18.4';
+    const DB_VERSION = '18.5';
 
     private $installed_version = null;
 
@@ -81,6 +81,9 @@ class WPBDP_Installer {
      */
     public function get_database_schema() {
         global $wpdb;
+
+        // https://core.trac.wordpress.org/ticket/33885.
+        $max_index_length 	= 191;
 
         $schema = array();
 
@@ -167,6 +170,20 @@ class WPBDP_Installer {
             actor varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT '',
             message text CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT '',
             data longblob NULL
+        ) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;";
+
+        $schema['statistics'] = "CREATE TABLE {$wpdb->prefix}wpbdp_statistics (
+            `id` bigint(20) PRIMARY KEY  AUTO_INCREMENT,
+            `listing_id` bigint(20) NULL DEFAULT 0,
+            `page_id` bigint(20) NULL DEFAULT 0,
+            `ip` VARCHAR($max_index_length) default NULL,
+            `views` mediumint(8) unsigned not null default 0,
+            `form_usage` mediumint(8) unsigned not null default 0,
+            `date_created` datetime NOT NULL default '0000-00-00 00:00:00',
+            KEY `stat_listing_id` (`listing_id` ASC ),
+            KEY `statistic_ip` (`ip`($max_index_length)),
+            KEY `statistic_object` (`listing_id` ASC, `id` ASC),
+            KEY `statistic_object_ip` (`listing_id` ASC, `id` ASC, `ip` ASC)
         ) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;";
 
         return apply_filters( 'wpbdp_database_schema', $schema );

--- a/includes/installer.php
+++ b/includes/installer.php
@@ -180,6 +180,7 @@ class WPBDP_Installer {
             `views` mediumint(8) unsigned not null default 0,
             `form_usage` mediumint(8) unsigned not null default 0,
             `date_created` datetime NOT NULL default '0000-00-00 00:00:00',
+            `date_updated` datetime NOT NULL default '0000-00-00 00:00:00',
             KEY `stat_listing_id` (`listing_id` ASC ),
             KEY `statistic_ip` (`ip`($max_index_length)),
             KEY `statistic_object` (`listing_id` ASC, `id` ASC),

--- a/includes/listings.php
+++ b/includes/listings.php
@@ -253,7 +253,7 @@ function wpbdp_get_listings_by_email( $email, $posts_per_page = -1, $offset = 0 
 
 /**
  * Save the listing statistic
- * 
+ *
  * @param int $listing_id - the listing id
  * @param int $page_id
  */
@@ -261,7 +261,7 @@ function wpbdp_save_listing_statistic( $listing_id, $page_id ) {
     if ( wpbdp_get_option( 'listings-stats-enabled' ) ) {
         $statistics = WPBDP_Listing_Statistic::get_instance();
         $can_save = true;
-        if ( current_user_can( 'administrator' ) && !wpbdp_get_option( 'listings-stats-admin-enabled' ) ) {
+        if ( current_user_can( 'administrator' ) && ! wpbdp_get_option( 'listings-stats-admin-enabled' ) ) {
             $can_save = false;
         }
         if ( $can_save ) {

--- a/includes/listings.php
+++ b/includes/listings.php
@@ -251,3 +251,22 @@ function wpbdp_get_listings_by_email( $email, $posts_per_page = -1, $offset = 0 
     return $post_ids;
 }
 
+/**
+ * Save the listing statistic
+ * 
+ * @param int $listing_id - the listing id
+ * @param int $page_id
+ */
+function wpbdp_save_listing_statistic( $listing_id, $page_id ) {
+    if ( wpbdp_get_option( 'listings-stats-enabled' ) ) {
+        $statistics = WPBDP_Listing_Statistic::instance();
+        $can_save = true;
+        if ( current_user_can( 'administrator' ) && !wpbdp_get_option( 'listings-stats-admin-enabled' ) ) {
+            $can_save = false;
+        }
+        if ( $can_save ) {
+            $ip = WPBDP_IP_Helper::get_user_ip();
+            $statistics->save_listing_view( $listing_id, $page_id, $ip );
+        }
+    }
+}

--- a/includes/listings.php
+++ b/includes/listings.php
@@ -259,7 +259,7 @@ function wpbdp_get_listings_by_email( $email, $posts_per_page = -1, $offset = 0 
  */
 function wpbdp_save_listing_statistic( $listing_id, $page_id ) {
     if ( wpbdp_get_option( 'listings-stats-enabled' ) ) {
-        $statistics = WPBDP_Listing_Statistic::instance();
+        $statistics = WPBDP_Listing_Statistic::get_instance();
         $can_save = true;
         if ( current_user_can( 'administrator' ) && !wpbdp_get_option( 'listings-stats-admin-enabled' ) ) {
             $can_save = false;

--- a/includes/models/listing/class-listing-statistic.php
+++ b/includes/models/listing/class-listing-statistic.php
@@ -15,6 +15,28 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WPBDP_Listing_Statistic {
 
+
+    /**
+	 * Class instance
+	 *
+	 * @var null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the class instance
+	 *
+	 * @return WPBDP_Listing_Statistic
+	 */
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+
     /**
      * Save or update a listing view
      * 

--- a/includes/models/listing/class-listing-statistic.php
+++ b/includes/models/listing/class-listing-statistic.php
@@ -134,7 +134,7 @@ class WPBDP_Listing_Statistic {
 
 	/**
 	 * Update views
-     * 
+     *
 	 * @param int $id - stat id
 	 * @param bool|object $db - the wp db object
 	 */

--- a/includes/models/listing/class-listing-statistic.php
+++ b/includes/models/listing/class-listing-statistic.php
@@ -39,7 +39,7 @@ class WPBDP_Listing_Statistic {
 
     /**
      * Save or update a listing view
-     * 
+     *
      * @param int $listing_id - the listing it
      * @param int $page_id - the page id
      * @param string $ip - the user ip
@@ -86,7 +86,7 @@ class WPBDP_Listing_Statistic {
 
 	/**
 	 * Delete stats by listing id
-     * 
+     *
 	 * @param int $listing_id - the form id
 	 */
 	public function delete_by_listing_id( $listing_id ) {
@@ -103,7 +103,7 @@ class WPBDP_Listing_Statistic {
 	 */
 	public function get_table_name() {
         global $wpdb;
-        $table_name = $wpdb->prefix."wpbdp_statistics";
+        $table_name = $wpdb->prefix.'wpbdp_statistics';
 		return $table_name;
 	}
 
@@ -137,7 +137,6 @@ class WPBDP_Listing_Statistic {
      * 
 	 * @param int $id - stat id
 	 * @param bool|object $db - the wp db object
-	 *
 	 */
 	private function _update( $id, $db = false ) {
 		if ( ! $db ) {

--- a/includes/models/listing/class-listing-statistic.php
+++ b/includes/models/listing/class-listing-statistic.php
@@ -9,26 +9,167 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
+/**
+ * Listing statistic model
+ * Handles database operations of the listing statistics
+ */
 class WPBDP_Listing_Statistic {
-    
-    /**
-     * The statistics table name
-     *
-     * @var string
-     */
-    private $table_name = '';
-
-
-    public function __construct() {
-        global $wpdb;
-        $this->table_name = $wpdb->prefix."wpbdp_statistics";
-    }
 
     /**
      * Save or update a listing view
+     * 
+     * @param int $listing_id - the listing it
+     * @param int $page_id - the page id
+     * @param string $ip - the user ip
      */
-    public function save_listing_view( $listing_id, $page_id ) {
+    public function save_listing_view( $listing_id, $page_id, $ip ) {
+        global $wpdb;
+        if ( ! defined( 'WPBDP_LISTING_VIEW_ENABLE_TRACK_IP' ) || ( defined( 'WPBDP_LISTING_VIEW_ENABLE_TRACK_IP' ) && ! WPBDP_LISTING_VIEW_ENABLE_TRACK_IP ) ) {
+			$ip = null;
+		}
+        if ( ! is_null( $ip ) ) {
+			$ip_query = ' AND `ip` = %s';
+		} else {
+			$ip_query = ' AND `ip` IS NULL';
+		}
 
+        $sql = "SELECT `id` FROM {$this->get_table_name()} WHERE `listing_id` = %d AND `page_id` = %d {$ip_query} AND `date_created` BETWEEN DATE_SUB(utc_timestamp(), INTERVAL 1 DAY) AND utc_timestamp()";
+
+        if ( ! is_null( $ip ) ) {
+			$prepared_sql = $wpdb->prepare( $sql, $listing_id, $page_id, $ip ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		} else {
+			$prepared_sql = $wpdb->prepare( $sql, $listing_id, $page_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+        $id = $wpdb->get_var( $prepared_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( $id ) {
+			$this->_update( $id, $wpdb );
+		} else {
+			$this->_save( $listing_id, $page_id, $ip, $wpdb );
+		}
     }
+
+	/**
+	 * Count views
+	 *
+	 * @param int $listing_id - the listing id
+	 * @param string $starting_date - the start date (dd-mm-yyy)
+	 * @param string $ending_date - the end date (dd-mm-yyy)
+	 *
+	 * @return int - totol views based on parameters
+	 */
+	public function count_views( $listing_id, $starting_date = null, $ending_date = null ) {
+		return $this->_count( $listing_id, $starting_date, $ending_date );
+	}
+
+	/**
+	 * Delete stats by listing id
+     * 
+	 * @param int $listing_id - the form id
+	 */
+	public function delete_by_listing_id( $listing_id ) {
+		global $wpdb;
+		$sql = "DELETE FROM {$this->get_table_name()} WHERE `listing_id` = %d";
+		$wpdb->query( $wpdb->prepare( $sql, $listing_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+
+    /**
+	 * Return statistics table name
+	 *
+	 * @return string
+	 */
+	public function get_table_name() {
+        global $wpdb;
+        $table_name = $wpdb->prefix."wpbdp_statistics";
+		return $table_name;
+	}
+
+    /**
+	 * Save Data to database
+	 *
+	 * @param int $listing_id - the listing id
+	 * @param int $page_id - the page id
+	 * @param string $ip - the user ip
+	 * @param bool|object $db - the wp db object
+	 */
+	private function _save( $listing_id, $page_id, $ip, $db = false ) {
+		if ( ! $db ) {
+			global $wpdb;
+			$db = $wpdb;
+		}
+
+		$db->insert(
+			$this->get_table_name(),
+			array(
+				'listing_id'   => $listing_id,
+				'page_id'      => $page_id,
+				'ip'           => $ip,
+				'date_created' => date_i18n( 'Y-m-d H:i:s' ),
+			)
+		);
+	}
+
+	/**
+	 * Update views
+     * 
+	 * @param int $id - stat id
+	 * @param bool|object $db - the wp db object
+	 *
+	 */
+	private function _update( $id, $db = false ) {
+		if ( ! $db ) {
+			global $wpdb;
+			$db = $wpdb;
+		}
+		$db->query( $db->prepare( "UPDATE {$this->get_table_name()} SET `views` = `views`+1, `date_updated` = now() WHERE `id` = %d", $id ) );
+	}
+
+    /**
+	 * Count data
+	 *
+	 * @param int $listing_id - the listing id
+	 * @param string $starting_date - the start date (dd-mm-yyy)
+	 * @param string $ending_date - the end date (dd-mm-yyy)
+	 *
+	 * @return int - totol counts based on parameters
+	 */
+	private function _count( $listing_id, $starting_date = null, $ending_date = null ) {
+		global $wpdb;
+		$date_query = $this->_generate_date_query( $wpdb, $starting_date, $ending_date );
+		$sql        = "SELECT SUM(`views`) FROM {$this->get_table_name()} WHERE `listing_id` = %d $date_query";
+		$counts     = $wpdb->get_var( $wpdb->prepare( $sql, $listing_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( $counts ) {
+			return $counts;
+		}
+
+		return 0;
+	}
+
+
+    /**
+	 * Generate the date query
+	 *
+	 * @param object $wpdb - the WordPress database object
+	 * @param string $starting_date - the start date (dd-mm-yyy)
+	 * @param string $ending_date - the end date (dd-mm-yyy)
+	 *
+	 * @return string $date_query
+	 */
+	private function _generate_date_query( $wpdb, $starting_date = null, $ending_date = null, $prefix = '', $clause = 'AND' ) {
+		$date_query  = '';
+		$date_format = '%d-%m-%Y';
+		if ( ! is_null( $starting_date ) && ! is_null( $ending_date ) && ! empty( $starting_date ) && ! empty( $ending_date ) ) {
+			$date_query = $wpdb->prepare( "$clause DATE_FORMAT($prefix`date_created`, '$date_format') >= %s AND DATE_FORMAT($prefix`date_created`, '$date_format') <= %s", $starting_date, $ending_date ); // phpcs:ignore
+		} else {
+			if ( ! is_null( $starting_date ) && ! empty( $starting_date ) ) {
+				$date_query = $wpdb->prepare( "$clause DATE_FORMAT($prefix`date_created`, '$date_format') >= %s", $starting_date ); // phpcs:ignore
+			} elseif ( ! is_null( $ending_date ) && ! empty( $ending_date ) ) {
+				$date_query = $wpdb->prepare( "$clause DATE_FORMAT($prefix`date_created`, '$date_format') <= %s", $starting_date ); // phpcs:ignore
+			}
+		}
+
+		return $date_query;
+	}
 }

--- a/includes/models/listing/class-listing-statistic.php
+++ b/includes/models/listing/class-listing-statistic.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ *
+ * @subpackage  Listing Statistic
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
+class WPBDP_Listing_Statistic {
+    
+    /**
+     * The statistics table name
+     *
+     * @var string
+     */
+    private $table_name = '';
+
+
+    public function __construct() {
+        global $wpdb;
+        $this->table_name = $wpdb->prefix."wpbdp_statistics";
+    }
+
+    /**
+     * Save or update a listing view
+     */
+    public function save_listing_view( $listing_id, $page_id ) {
+
+    }
+}


### PR DESCRIPTION
Adds listing statistics.

- [ ] New admin setting, a sub-tab under the `Listings` tab called `Statistics` `/wp-admin/admin.php?page=wpbdp_settings&tab=listings&subtab=listings%2Fstats`
- [ ] Option to turn `off` or `on` and to allow tracking of admins. Defaults to `off` for both
- [ ] New column in Listings called `Views` that will only appear if `Enable statistics?` is checked
- [ ] Statistics saved in a new database table `{database_prefix}_statistics`
- [ ] Views are counted once per user per day
- [ ] Constant check in the Statistics model called `WPBDP_LISTING_VIEW_ENABLE_TRACK_IP` that when defined as false, does not track the IP of users 