### PR TITLE
Hide image from searchable field type in list

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -424,6 +424,10 @@ final class WPBDP__Settings__Bootstrap {
                 $text_fields[] = $field->get_id();
             }
 
+            if ( in_array( $field->get_field_type_id(), array( 'image' ) ) ) {
+                continue;
+            }
+            
             $fields[ $field->get_id() ] = $field->get_label();
         }
 

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -427,7 +427,7 @@ final class WPBDP__Settings__Bootstrap {
             if ( in_array( $field->get_field_type_id(), array( 'image' ) ) ) {
                 continue;
             }
-            
+
             $fields[ $field->get_id() ] = $field->get_label();
         }
 


### PR DESCRIPTION
Fixes issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4871 . 
Image field type will not be visible in the searchable field types