### PR TITLE
Fix Fee Plans Views

### DIFF
--- a/includes/admin/helpers/class-fees-table.php
+++ b/includes/admin/helpers/class-fees-table.php
@@ -38,9 +38,6 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
             case 'active':
                 $view_name = _x( 'Active', 'fees admin', 'business-directory-plugin' );
                 break;
-            case 'unavailable':
-                $view_name = _x( 'Not Available', 'fees admin', 'business-directory-plugin' );
-                break;
             case 'disabled':
                 $view_name = _x( 'Disabled', 'fees admin', 'business-directory-plugin' );
                 break;
@@ -82,7 +79,7 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
         );
 
         if ( ! wpbdp_payments_possible() ) {
-            $active = $all - $non_free - $disabled;
+            $active = $all - $disabled;
         } else {
             $active = $non_free;
         }
@@ -95,15 +92,6 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
             number_format_i18n( $active )
         );
 
-        $unavailable = $all - $active - $disabled;
-
-        $views['unavailable'] = sprintf(
-            '<a href="%s" class="%s">%s</a> <span class="count">(%s)</span></a>',
-            esc_url( add_query_arg( 'fee_status', 'unavailable', $admin_fees_url ) ),
-            'unavailable' === $this->get_current_view() ? 'current' : '',
-            _x( 'Not Available', 'admin fees table', 'business-directory-plugin' ),
-            number_format_i18n( $unavailable )
-        );
 
         $views['disabled'] = sprintf(
             '<a href="%s" class="%s">%s</a> <span class="count">(%s)</span></a>',
@@ -131,27 +119,19 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
     public function prepare_items() {
         $this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
 
-        $args = array();
+        $args = array(
+            'admin_view' => true // Admin view shows all listings
+        );
 
         switch ( $this->get_current_view() ) {
 			case 'active':
 				$args['enabled']      = 1;
-				$args['include_free'] = ! wpbdp_payments_possible();
+				$args['include_free'] = true;
+                $args['tag']          = '';
                 break;
 			case 'disabled':
 				$args['enabled'] = 0;
 				$args['tag']     = ''; // FIXME: Without tag = '', you only get disabled free fees.
-
-                break;
-			case 'unavailable':
-				if ( wpbdp_payments_possible() ) {
-					$args['enabled'] = 'all';
-					$args['tag']     = 'free';
-				} else {
-					$args['enabled']      = 1;
-					$args['include_free'] = false;
-					$args['tag']          = ''; // FIXME: Without tag = '', include_free is ignored.
-				}
 
                 break;
 			case 'all':

--- a/includes/admin/helpers/class-fees-table.php
+++ b/includes/admin/helpers/class-fees-table.php
@@ -92,7 +92,6 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
             number_format_i18n( $active )
         );
 
-
         $views['disabled'] = sprintf(
             '<a href="%s" class="%s">%s</a> <span class="count">(%s)</span></a>',
             esc_url( add_query_arg( 'fee_status', 'disabled', $admin_fees_url ) ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -847,12 +847,13 @@ function wpbdp_get_fee_plans( $args = array() ) {
 
     $defaults = array(
         'enabled'         => 1,
-        'include_free'    => wpbdp_payments_possible() ? false : true,
-        'tag'             => wpbdp_payments_possible() ? '' : 'free',
+        'include_free'    => true,
+        'tag'             => '',
         'orderby'         => 'label',
         'order'           => 'ASC',
         'categories'      => array(),
         'include_private' => false,
+        'admin_view'      => wpbdp_payments_possible()
     );
     if ( $order = wpbdp_get_option( 'fee-order' ) ) {
         $defaults['orderby'] = ( 'custom' == $order['method'] ) ? 'weight' : $order['method'];
@@ -871,8 +872,12 @@ function wpbdp_get_fee_plans( $args = array() ) {
         $where .= $wpdb->prepare( ' AND p.tag = %s', $args['tag'] );
     }
 
-    if ( ! $args['include_free'] && 'free' != $args['tag'] ) {
+    if ( ! $args['admin_view'] && ( ! $args['include_free'] && 'free' != $args['tag'] ) ) {
         $where .= $wpdb->prepare( ' AND p.tag != %s', 'free' );
+    }
+
+    if ( ! $args['admin_view'] ) {
+        $where .= $wpdb->prepare( ' AND p.amount = %d', 0 );
     }
 
     $categories = $args['categories'];


### PR DESCRIPTION
This fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4932 and an issue reported on https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4691

- Added a new argument called `admin_view` in the `wpbdp_get_fee_plans()` function. This allows showing all fees, regardless of payment status to be active. By default, it will only show fees based on the payment status.
- Remove the `unavailable` fee status and make all new free fees as active. This also shows the fees in the drop down select