### PR TITLE
Add filter for listing owner mode

### DIFF
--- a/includes/admin/class-listing-owner.php
+++ b/includes/admin/class-listing-owner.php
@@ -141,16 +141,16 @@ class WPBDP__Admin__Listing_Owner {
      */
     private function get_mode( $params ) {
         if ( $params['mode'] ) {
-            return $params['mode'];
+            return apply_filters( 'wpbdp_admin_listing_owner_mode', $params['mode'] );
         }
 
         $users_count = count_users();
 
         if ( isset( $users_count['total_users'] ) && $users_count['total_users'] > 100 ) {
-            return 'ajax';
+            return apply_filters( 'wpbdp_admin_listing_owner_mode', 'ajax' );
         }
 
-        return 'inline';
+        return apply_filters( 'wpbdp_admin_listing_owner_mode', 'inline' );
     }
 
     /**


### PR DESCRIPTION
This adds a solution to https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4917

Introduced a filter called `wpbdp_admin_listing_owner_mode` that allows the site owner to override the listing owner mode used. To test, you can generate Fake users using [FakerPress](https://wordpress.org/plugins/fakerpress/) plugin (more than 200 users will be needed). By default it will show the ajax list for users in the listing edit page.
To test the filter, a sample code will be :

```
add_filter( 'wpbdp_admin_listing_owner_mode', 'wpbdp_admin_listing_owner_mode' );
function wpbdp_admin_listing_owner_mode( $mode ) {
	return 'inline';
}
```

This will force the drop down to show all the users and not use the ajax method. The values for the return string are either:

- `inline` for inline (show all users)
- `ajax` for ajax select mode (type to search for a user)