### PR TITLE
Listing image performance improvements

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -477,14 +477,14 @@ function _wpbdp_should_image_be_resized( $id, $args = array() ) {
 		return false;
 	}
 
-	$def_width = absint( isset( $args['width'] ) ?  $args['width'] : wpbdp_get_option( 'thumbnail-width' ) );
+	$def_width = absint( isset( $args['width'] ) ? $args['width'] : wpbdp_get_option( 'thumbnail-width' ) );
 	$width     = isset( $metadata['width'] ) ? absint( $metadata['width'] ) : 0;
 
 	if ( ! $width || $width <= $def_width ) {
 		return false;
 	}
 
-	$def_height = absint( isset( $args['height'] ) ?  $args['height'] : wpbdp_get_option( 'thumbnail-height' ) );
+	$def_height = absint( isset( $args['height'] ) ? $args['height'] : wpbdp_get_option( 'thumbnail-height' ) );
 	$height     = isset( $metadata['height'] ) ? absint( $metadata['height'] ) : 0;
 
 	if ( ! $height || $height <= $def_height ) {

--- a/includes/helpers/class-authenticated-listing-view.php
+++ b/includes/helpers/class-authenticated-listing-view.php
@@ -17,7 +17,7 @@ class WPBDP__Authenticated_Listing_View extends WPBDP__View {
 			content: '" . esc_attr__( 'Selected', 'business-directory-plugin' ) . "';
 		}";
 		wp_add_inline_style( 'wpbdp-base-css', $custom_css );
-		
+
 		$this->enqueue_custom_resources();
 	}
 

--- a/includes/helpers/class-listing-display-helper.php
+++ b/includes/helpers/class-listing-display-helper.php
@@ -275,7 +275,7 @@ class WPBDP_Listing_Display_Helper {
         $crop           = wpbdp_get_option( 'thumbnail-crop' );
         foreach ( $listing_images as $img_id ) {
             // Correct size of thumbnail if needed.
-            _wpbdp_resize_image_if_needed( 
+            _wpbdp_resize_image_if_needed(
                 $img_id,
                 array(
                     'width'  => $def_width,


### PR DESCRIPTION
Reported https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4979

- Added second argument to the function `_wpbdp_resize_image_if_needed` called `$args` that allows of passing of width, height and crop arguments as an array to prevent querying the options when function is used in a loop
- Added a filter `wpbdp_resize_image_if_needed` that accepts the arguments `$resize (bool)`, `$id`, `$args` . The filter can be used to skip resizing of a specific or all images if the site owner does not want the images to be resized. By default it returns `true` to allow resizing