### PR TITLE
Hide payment form when not recurring and when price is 0

### DIFF
--- a/includes/controllers/pages/class-checkout.php
+++ b/includes/controllers/pages/class-checkout.php
@@ -178,7 +178,7 @@ class WPBDP__Views__Checkout extends WPBDP__View {
         $pay_now = ( $this->payment->has_item_type( 'recurring_plan' ) || $this->payment->amount > 0 );
         $checkout_form .= sprintf(
             '<div class="wpbdp-checkout-submit"><input type="submit" value="%s" /></div>',
-            $pay_now ? _x( 'Pay Now', 'checkout', 'business-directory-plugin' ) : _x( 'Complete', 'checkout', 'business-directory-plugin' )
+            $this->payment->show_payment_options() ? _x( 'Pay Now', 'checkout', 'business-directory-plugin' ) : _x( 'Complete', 'checkout', 'business-directory-plugin' )
         );
 
         return $checkout_form;

--- a/includes/controllers/pages/class-checkout.php
+++ b/includes/controllers/pages/class-checkout.php
@@ -177,7 +177,7 @@ class WPBDP__Views__Checkout extends WPBDP__View {
         // $checkout_form .= wpbdp_capture_action( 'wpbdp_checkout_form_bottom', $this->payment );
         $checkout_form .= sprintf(
             '<div class="wpbdp-checkout-submit"><input type="submit" value="%s" /></div>',
-            $this->payment->show_payment_options() ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Complete', 'business-directory-plugin' )
+            $this->payment->show_payment_options() ? esc_attr__( 'Pay Now', 'business-directory-plugin' ) : esc_attr__( 'Complete', 'business-directory-plugin' )
         );
 
         return $checkout_form;

--- a/includes/controllers/pages/class-checkout.php
+++ b/includes/controllers/pages/class-checkout.php
@@ -175,7 +175,11 @@ class WPBDP__Views__Checkout extends WPBDP__View {
         // $checkout_form .= wpbdp_capture_action( 'wpbdp_checkout_form_top', $this->payment );
         $checkout_form .= $this->gateway->render_form( $this->payment, $this->errors );
         // $checkout_form .= wpbdp_capture_action( 'wpbdp_checkout_form_bottom', $this->payment );
-        $checkout_form .= '<div class="wpbdp-checkout-submit"><input type="submit" value="' . _x( 'Pay Now', 'checkout', 'business-directory-plugin' ) . '" /></div>';
+        $pay_now = ( $this->payment->has_item_type( 'recurring_plan' ) || $this->payment->amount > 0 );
+        $checkout_form .= sprintf(
+            '<div class="wpbdp-checkout-submit"><input type="submit" value="%s" /></div>',
+            $pay_now ? _x( 'Pay Now', 'checkout', 'business-directory-plugin' ) : _x( 'Complete', 'checkout', 'business-directory-plugin' )
+        );
 
         return $checkout_form;
     }

--- a/includes/controllers/pages/class-checkout.php
+++ b/includes/controllers/pages/class-checkout.php
@@ -175,10 +175,9 @@ class WPBDP__Views__Checkout extends WPBDP__View {
         // $checkout_form .= wpbdp_capture_action( 'wpbdp_checkout_form_top', $this->payment );
         $checkout_form .= $this->gateway->render_form( $this->payment, $this->errors );
         // $checkout_form .= wpbdp_capture_action( 'wpbdp_checkout_form_bottom', $this->payment );
-        $pay_now = ( $this->payment->has_item_type( 'recurring_plan' ) || $this->payment->amount > 0 );
         $checkout_form .= sprintf(
             '<div class="wpbdp-checkout-submit"><input type="submit" value="%s" /></div>',
-            $this->payment->show_payment_options() ? _x( 'Pay Now', 'checkout', 'business-directory-plugin' ) : _x( 'Complete', 'checkout', 'business-directory-plugin' )
+            $this->payment->show_payment_options() ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Complete', 'business-directory-plugin' )
         );
 
         return $checkout_form;

--- a/includes/models/class-payment.php
+++ b/includes/models/class-payment.php
@@ -387,5 +387,17 @@ class WPBDP_Payment extends WPBDP__DB__Model {
     public static function objects() {
         return parent::_objects( get_class() );
     }
+
+	/**
+	 * Check if the payment is recurring or the amount is greater than 0.
+	 * This is used to show the payment options when price can be 0 or if is recurring.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	public function show_payment_options() {
+		return ( $this->has_item_type( 'recurring_plan' ) || $this->amount > 0 );
+	}
 }
 

--- a/includes/models/class-payment.php
+++ b/includes/models/class-payment.php
@@ -287,7 +287,7 @@ class WPBDP_Payment extends WPBDP__DB__Model {
         $url = wpbdp_url( 'checkout', $this->payment_key );
 
         if ( ! $force_http && ! is_ssl() ) {
-            $url = set_url_scheme( $url, 'https' );
+            //$url = set_url_scheme( $url, 'https' );
         }
 
         return $url;

--- a/includes/models/class-payment.php
+++ b/includes/models/class-payment.php
@@ -287,7 +287,7 @@ class WPBDP_Payment extends WPBDP__DB__Model {
         $url = wpbdp_url( 'checkout', $this->payment_key );
 
         if ( ! $force_http && ! is_ssl() ) {
-            //$url = set_url_scheme( $url, 'https' );
+            $url = set_url_scheme( $url, 'https' );
         }
 
         return $url;

--- a/templates/checkout.tpl.php
+++ b/templates/checkout.tpl.php
@@ -32,15 +32,16 @@
         <?php endif; ?>
     </div>
 
-
-    <div class="wpbdp-checkout-gateway-selection wpbdp-checkout-section">
-        <h3><?php _ex( 'Select a Payment Method', 'checkout', 'business-directory-plugin' ); ?></h3>
-        <?php foreach ( wpbdp()->payment_gateways->get_available_gateways( array( 'currency_code' => $payment->currency_code ) ) as $gateway ) : ?>
-        <label><input type="radio" name="gateway" value="<?php echo $gateway->get_id(); ?>" <?php checked( $chosen_gateway->get_id(), $gateway->get_id() ); ?>/> <?php echo $gateway->get_logo(); ?></label>
-        <?php endforeach; ?>
-        <div class="wpbdp-checkout-submit wpbdp-no-js"><input type="submit" value="<?php esc_html_e( 'Next', 'business-directory-plugin' ); ?>" /></div>
-    </div>
-    <!-- end .wpbdp-checkout-gateway-selection -->
+	<?php if ( $payment->amount > 0 || $payment->has_item_type( 'recurring_plan' ) ) : ?>
+		<div class="wpbdp-checkout-gateway-selection wpbdp-checkout-section">
+			<h3><?php _ex( 'Select a Payment Method', 'checkout', 'business-directory-plugin' ); ?></h3>
+			<?php foreach ( wpbdp()->payment_gateways->get_available_gateways( array( 'currency_code' => $payment->currency_code ) ) as $gateway ) : ?>
+			<label><input type="radio" name="gateway" value="<?php echo $gateway->get_id(); ?>" <?php checked( $chosen_gateway->get_id(), $gateway->get_id() ); ?>/> <?php echo $gateway->get_logo(); ?></label>
+			<?php endforeach; ?>
+			<div class="wpbdp-checkout-submit wpbdp-no-js"><input type="submit" value="<?php esc_html_e( 'Next', 'business-directory-plugin' ); ?>" /></div>
+		</div>
+		<!-- end .wpbdp-checkout-gateway-selection -->
+	<?php endif; ?>
 
     <div id="wpbdp-checkout-form-fields" class="wpbdp-payment-gateway-<?php echo $chosen_gateway->get_id(); ?>-form-fields">
         <?php echo $checkout_form; ?>

--- a/templates/checkout.tpl.php
+++ b/templates/checkout.tpl.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<h2><?php _ex( 'Checkout', 'checkout', 'business-directory-plugin' ); ?></h2>
+<h2><?php esc_html_e( 'Checkout', 'business-directory-plugin' ); ?></h2>
 
 <div class="wpbdp-payment-invoice">
     <?php echo $invoice; ?>
@@ -28,15 +28,15 @@
         <?php endif; ?>
         
         <?php if ( $payment->has_item_type( 'discount_code' ) && $payment->has_item_type( 'recurring_plan' ) && 0.0 == $payment->amount ) : ?>
-            <div class="wpbdp-msg notice"><?php _ex( 'Recurring fee plans require a payment method to renew your listing at the end of the term.', 'checkout', 'business-directory-plugin' ); ?></div>
+            <div class="wpbdp-msg notice"><?php esc_html_e( 'Recurring fee plans require a payment method to renew your listing at the end of the term.', 'business-directory-plugin' ); ?></div>
         <?php endif; ?>
     </div>
 
 	<?php if ( $payment->show_payment_options() ) : ?>
 		<div class="wpbdp-checkout-gateway-selection wpbdp-checkout-section">
-			<h3><?php _ex( 'Select a Payment Method', 'checkout', 'business-directory-plugin' ); ?></h3>
+			<h3><?php esc_html_e( 'Select a Payment Method', 'business-directory-plugin' ); ?></h3>
 			<?php foreach ( wpbdp()->payment_gateways->get_available_gateways( array( 'currency_code' => $payment->currency_code ) ) as $gateway ) : ?>
-			<label><input type="radio" name="gateway" value="<?php echo $gateway->get_id(); ?>" <?php checked( $chosen_gateway->get_id(), $gateway->get_id() ); ?>/> <?php echo $gateway->get_logo(); ?></label>
+			<label><input type="radio" name="gateway" value="<?php echo esc_attr( $gateway->get_id() ); ?>" <?php checked( $chosen_gateway->get_id(), $gateway->get_id() ); ?>/> <?php echo $gateway->get_logo(); ?></label>
 			<?php endforeach; ?>
 			<div class="wpbdp-checkout-submit wpbdp-no-js"><input type="submit" value="<?php esc_html_e( 'Next', 'business-directory-plugin' ); ?>" /></div>
 		</div>

--- a/templates/checkout.tpl.php
+++ b/templates/checkout.tpl.php
@@ -32,7 +32,7 @@
         <?php endif; ?>
     </div>
 
-	<?php if ( $payment->amount > 0 || $payment->has_item_type( 'recurring_plan' ) ) : ?>
+	<?php if ( $payment->show_payment_options() ) : ?>
 		<div class="wpbdp-checkout-gateway-selection wpbdp-checkout-section">
 			<h3><?php _ex( 'Select a Payment Method', 'checkout', 'business-directory-plugin' ); ?></h3>
 			<?php foreach ( wpbdp()->payment_gateways->get_available_gateways( array( 'currency_code' => $payment->currency_code ) ) as $gateway ) : ?>


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4993

- If the plan is not recurring and an discount code of 100% is applied, the payment options are hidden
- If the plan is recurring but there is a discount code of 100%, the payment options will be shown
- If it is full price, the payment options will be shown