### PR TITLE
Complete never expiring listings set to publish

### DIFF
--- a/includes/admin/controllers/class-admin-listings.php
+++ b/includes/admin/controllers/class-admin-listings.php
@@ -611,10 +611,10 @@ class WPBDP_Admin_Listings {
 		}
 
 		// Check if the status needs to be changed.
-		if ( 'expired' == $listing->get_status() ) {
-			if ( ! $row['expiration_date'] || $not_expired ) {
-				$listing->get_status( true, true );
-			}
+		if ( 'expired' == $listing->get_status() && ( ! $row['expiration_date'] || $not_expired ) ) {
+			$listing->get_status( true, true );
+		} elseif ( 'complete' == $listing->get_status() && ( ! $row['expiration_date'] || $not_expired ) ) {
+			$listing->update_post_status( wpbdp_get_option( 'edit-post-status' ) );
 		} elseif ( ! $not_expired ) {
 			$listing->set_status( 'expired' );
 		}

--- a/includes/admin/controllers/class-admin-listings.php
+++ b/includes/admin/controllers/class-admin-listings.php
@@ -614,7 +614,7 @@ class WPBDP_Admin_Listings {
 		if ( 'expired' == $listing->get_status() && ( ! $row['expiration_date'] || $not_expired ) ) {
 			$listing->get_status( true, true );
 		} elseif ( 'complete' == $listing->get_status() && ( ! $row['expiration_date'] || $not_expired ) ) {
-			$listing->update_post_status( wpbdp_get_option( 'edit-post-status' ) );
+			$listing->update_post_status( 'publish' );
 		} elseif ( ! $not_expired ) {
 			$listing->set_status( 'expired' );
 		}


### PR DESCRIPTION
This is in reference to https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4998

When a listing that is set to never expire is approved by the admin, by clicking the publish button, the listing status should go direct to publish. At the moment it requires 2 clicks : first status is updated from "Pending Review" to "Draft". Then from "Draft" to "Publish". This skips the two steps