### PR TITLE
Don't switch listings with no expiration to draft

### DIFF
--- a/includes/admin/controllers/class-admin-listings.php
+++ b/includes/admin/controllers/class-admin-listings.php
@@ -615,7 +615,7 @@ class WPBDP_Admin_Listings {
 			if ( ! $row['expiration_date'] || $not_expired ) {
 				$listing->get_status( true, true );
 			}
-		} elseif ( ! $not_expired ) {
+		} elseif ( ! $not_expired && $row['expiration_date'] ) {
 			$listing->set_status( 'expired' );
 		}
     }


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4998

When editing a listing on the back-end with no expiration date, clicking publish always ends up in draft mode. I'm not entirely sure where else this was showing up.