### PR TITLE
Function to get module information

### DIFF
--- a/includes/class-modules.php
+++ b/includes/class-modules.php
@@ -66,4 +66,20 @@ class WPBDP__Modules {
         }
     }
 
+	/**
+	 * Get module information.
+	 *
+	 * @param string $module_id The module id.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool|object Returns false if module is not loaded. Returns an object if loaded
+	 */
+	public function get_module_info( $module_id ) {
+		if ( ! $this->is_loaded( $module_id ) ) {
+			return false;
+		}
+		$module = $this->modules[ $module_id ];
+		return $module;
+	}
 }


### PR DESCRIPTION
Extra function to get module info

```
global $wpbdp;
$module   = $wpbdp->modules->get_module_info( 'premium' );
$version    = $module->version;
```

