### PR TITLE
Listing title single view as part

### DIFF
--- a/templates/parts/listing-title.tpl.php
+++ b/templates/parts/listing-title.tpl.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Listing title
+ *
+ * @package BDP/Templates/parts
+ */
+?>
+<div class="listing-title">
+	<<?php echo esc_attr( $title_type ); ?>><?php echo esc_html( $title ); ?></<?php echo esc_attr( $title_type ); ?>>
+	<?php if ( in_array( 'single', wpbdp_get_option( 'display-sticky-badge' ) ) ) : ?>
+		<?php echo $sticky_tag; ?>
+	<?php endif; ?>
+</div>

--- a/templates/single.tpl.php
+++ b/templates/single.tpl.php
@@ -8,13 +8,7 @@
 
 <div id="<?php echo esc_attr( $listing_css_id ); ?>" class="<?php echo esc_attr( $listing_css_class ); ?>">
     <?php wpbdp_get_return_link(); ?>
-    <div class="listing-title">
-        <<?php echo esc_attr( $title_type ); ?>><?php echo esc_html( $title ); ?></<?php echo esc_attr( $title_type ); ?>>
-	    <?php if ( in_array( 'single', wpbdp_get_option( 'display-sticky-badge' ) ) ) : ?>
-	        <?php echo $sticky_tag; ?>
-	    <?php endif; ?>
-    </div>
-
+	<?php wpbdp_x_part( 'parts/listing-title' ); ?>
     <?php
 	wpbdp_x_part(
 		'parts/listing-buttons',


### PR DESCRIPTION
Most themes that extend have the listing title section repeated. This will make it easier to include the same title template part in all themes