### PR TITLE
Delete directory clear cache

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,6 +87,9 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
+			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
+			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
+
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
 
@@ -1215,6 +1218,31 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
             echo '<script>jQuery(document).ready(function(){wpbdpSelectSubnav();});</script>';
         }
+
+		/**
+		 * Action called before a post is trashed.
+		 *
+		 * @since x.x
+		 */
+		public function before_trash_post( $check, $post ) {
+			$this->before_delete_post( $check, $post, false );
+			return $check;
+		}
+
+		/**
+		 * Action called before post is deleted.
+		 * Delete transient of saved directory ids if a directory page is deleted.
+		 *
+		 * @since x.x
+		 */
+		public function before_delete_post( $check, $post, $force_delete ) {
+			if ( 'page' === $post->post_type ) {
+				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
+					wpbdp_delete_page_ids_cache();
+				}
+			}
+			return $check;
+		}
 
         /**
          * This function restores Manage Regions menu for Editors,

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,6 +87,9 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
+			add_filter( 'pre_trash_post', array( &$this, 'before_trash_post' ), 10, 2 );
+			add_filter( 'pre_delete_post', array( &$this, 'before_delete_post' ), 10, 3 );
+
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
 
@@ -1215,6 +1218,28 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
             echo '<script>jQuery(document).ready(function(){wpbdpSelectSubnav();});</script>';
         }
+
+		/**
+		 * Action called before a post is trashed.
+		 */
+		public function before_trash_post( $check, $post ) {
+			return $this->before_delete_post( $check, $post, false );
+		}
+
+		/**
+		 * Action called before post is deleted.
+		 * Delete transient of saved directory ids if a directory page is deleted.
+		 *
+		 * @since x.x
+		 */
+		public function before_delete_post( $check, $post, $force_delete ) {
+			if ( 'page' === $post->post_type ) {
+				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
+					wpbdp_delete_page_ids_cache();
+				}
+			}
+			return $check;
+		}
 
         /**
          * This function restores Manage Regions menu for Editors,

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,13 +87,6 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
-			// Clear listing page cache.
-			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
-			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
-
-			// Add post state.
-			add_filter( 'display_post_states', array( $this, 'add_post_state' ), 10, 2 );
-
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
 
@@ -1222,61 +1215,6 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
             echo '<script>jQuery(document).ready(function(){wpbdpSelectSubnav();});</script>';
         }
-
-		/**
-		 * Action called before a post is trashed.
-		 *
-		 * @since x.x
-		 */
-		public function before_trash_post( $check, $post ) {
-			$this->before_delete_post( $check, $post, false );
-			return $check;
-		}
-
-		/**
-		 * Action called before post is deleted.
-		 * Delete transient of saved directory ids if a directory page is deleted.
-		 *
-		 * @since x.x
-		 */
-		public function before_delete_post( $check, $post, $force_delete ) {
-			if ( 'page' === $post->post_type ) {
-				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
-					wpbdp_delete_page_ids_cache();
-				}
-			}
-			return $check;
-		}
-
-		/**
-		 * This filter is called by WordPress when the page-listtable is created to
-		 * display all available Posts/Pages. We use this filter to add a note
-		 * to all pages that are special membership pages.
-		 *
-		 * @param  array   $states The states
-		 * @param  WP_Post $post The current post
-		 *
-		 * @since  x.x
-		 *
-		 * @return array
-		 */
-		public function add_post_state( $states, $post ) {
-			if ( 'page' !== $post->post_type ) {
-				return $states;
-			}
-			$base_id = wpbdp_get_page_id( 'main' );
-			if ( ! $base_id ) {
-				return $states;
-			}
-			if ( $post->ID === (int) $base_id ) {
-				$states['wpbdp_page'] = sprintf(
-					'<span style="%2$s">%1$s</span>',
-					__( 'Directory Page', 'business-directory-plugin' ),
-					'background:#aaa;color:#fff;padding:1px 4px;border-radius:4px;font-size:0.8em'
-				);
-			}
-			return $states;
-		}
 
         /**
          * This function restores Manage Regions menu for Editors,

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -88,7 +88,6 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
 			// Clear listing page cache.
-			add_filter( 'pre_trash_post', array( $this, 'before_delete_post' ), 10, 2 );
 			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 2 );
 
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
@@ -1221,7 +1220,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
         }
 
 		/**
-		 * Action called before post is deleted or trashed.
+		 * Action called before post is deleted.
 		 * Delete cached directory ids if a page is deleted.
 		 *
 		 * @since x.x

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -88,8 +88,8 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
 			// Clear listing page cache.
-			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
-			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
+			add_filter( 'pre_trash_post', array( $this, 'before_delete_post' ), 10, 2 );
+			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 2 );
 
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
@@ -1221,26 +1221,14 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
         }
 
 		/**
-		 * Action called before a post is trashed.
+		 * Action called before post is deleted or trashed.
+		 * Delete cached directory ids if a page is deleted.
 		 *
 		 * @since x.x
 		 */
-		public function before_trash_post( $check, $post ) {
-			$this->before_delete_post( $check, $post, false );
-			return $check;
-		}
-
-		/**
-		 * Action called before post is deleted.
-		 * Delete transient of saved directory ids if a directory page is deleted.
-		 *
-		 * @since x.x
-		 */
-		public function before_delete_post( $check, $post, $force_delete ) {
+		public function before_delete_post( $check, $post ) {
 			if ( 'page' === $post->post_type ) {
-				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
-					wpbdp_delete_page_ids_cache();
-				}
+				wpbdp_delete_page_ids_cache();
 			}
 			return $check;
 		}

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,8 +87,12 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
+			// Clear listing page cache.
 			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
 			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
+
+			// Add post state.
+			add_filter( 'display_post_states', array( $this, 'add_post_state' ), 10, 2 );
 
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
@@ -1242,6 +1246,36 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 				}
 			}
 			return $check;
+		}
+
+		/**
+		 * This filter is called by WordPress when the page-listtable is created to
+		 * display all available Posts/Pages. We use this filter to add a note
+		 * to all pages that are special membership pages.
+		 *
+		 * @param  array   $states The states
+		 * @param  WP_Post $post The current post
+		 *
+		 * @since  x.x
+		 *
+		 * @return array
+		 */
+		public function add_post_state( $states, $post ) {
+			if ( 'page' !== $post->post_type ) {
+				return $states;
+			}
+			$base_id = wpbdp_get_page_id( 'main' );
+			if ( ! $base_id ) {
+				return $states;
+			}
+			if ( $post->ID === (int) $base_id ) {
+				$states['wpbdp_page'] = sprintf(
+					'<span style="%2$s">%1$s</span>',
+					__( 'Directory Page', 'business-directory-plugin' ),
+					'background:#aaa;color:#fff;padding:1px 4px;border-radius:4px;font-size:0.8em',
+				);
+			}
+			return $states;
 		}
 
         /**

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,6 +87,10 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
+			// Clear listing page cache.
+			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
+			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
+
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
 
@@ -1215,6 +1219,31 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
             echo '<script>jQuery(document).ready(function(){wpbdpSelectSubnav();});</script>';
         }
+
+		/**
+		 * Action called before a post is trashed.
+		 *
+		 * @since x.x
+		 */
+		public function before_trash_post( $check, $post ) {
+			$this->before_delete_post( $check, $post, false );
+			return $check;
+		}
+
+		/**
+		 * Action called before post is deleted.
+		 * Delete transient of saved directory ids if a directory page is deleted.
+		 *
+		 * @since x.x
+		 */
+		public function before_delete_post( $check, $post, $force_delete ) {
+			if ( 'page' === $post->post_type ) {
+				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
+					wpbdp_delete_page_ids_cache();
+				}
+			}
+			return $check;
+		}
 
         /**
          * This function restores Manage Regions menu for Editors,

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,8 +87,8 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
-			add_filter( 'pre_trash_post', array( &$this, 'before_trash_post' ), 10, 2 );
-			add_filter( 'pre_delete_post', array( &$this, 'before_delete_post' ), 10, 3 );
+			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
+			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
 
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -1272,7 +1272,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 				$states['wpbdp_page'] = sprintf(
 					'<span style="%2$s">%1$s</span>',
 					__( 'Directory Page', 'business-directory-plugin' ),
-					'background:#aaa;color:#fff;padding:1px 4px;border-radius:4px;font-size:0.8em',
+					'background:#aaa;color:#fff;padding:1px 4px;border-radius:4px;font-size:0.8em'
 				);
 			}
 			return $states;

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -1221,9 +1221,12 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
 		/**
 		 * Action called before a post is trashed.
+		 *
+		 * @since x.x
 		 */
 		public function before_trash_post( $check, $post ) {
-			return $this->before_delete_post( $check, $post, false );
+			$this->before_delete_post( $check, $post, false );
+			return $check;
 		}
 
 		/**

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -87,9 +87,6 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			add_filter( 'admin_head-edit.php', array( $this, 'maybe_highlight_menu' ) );
 			add_filter( 'admin_head-edit-tags.php', array( $this, 'maybe_highlight_menu' ) );
 
-			add_filter( 'pre_trash_post', array( $this, 'before_trash_post' ), 10, 2 );
-			add_filter( 'pre_delete_post', array( $this, 'before_delete_post' ), 10, 3 );
-
 			require_once WPBDP_PATH . 'includes/controllers/class-addons.php';
 			WPBDP_Addons_Controller::load_hooks();
 
@@ -1218,31 +1215,6 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
             echo '<script>jQuery(document).ready(function(){wpbdpSelectSubnav();});</script>';
         }
-
-		/**
-		 * Action called before a post is trashed.
-		 *
-		 * @since x.x
-		 */
-		public function before_trash_post( $check, $post ) {
-			$this->before_delete_post( $check, $post, false );
-			return $check;
-		}
-
-		/**
-		 * Action called before post is deleted.
-		 * Delete transient of saved directory ids if a directory page is deleted.
-		 *
-		 * @since x.x
-		 */
-		public function before_delete_post( $check, $post, $force_delete ) {
-			if ( 'page' === $post->post_type ) {
-				if ( strpos( $post->post_content, '[businessdirectory]' ) !== false ) {
-					wpbdp_delete_page_ids_cache();
-				}
-			}
-			return $check;
-		}
 
         /**
          * This function restores Manage Regions menu for Editors,

--- a/includes/class-wpbdp.php
+++ b/includes/class-wpbdp.php
@@ -349,7 +349,7 @@ final class WPBDP {
 
     public function plugin_activation() {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
-		wpbdp_delete_page_ids_cache()
+		wpbdp_delete_page_ids_cache();
     }
 
     public function plugin_deactivation() {

--- a/includes/class-wpbdp.php
+++ b/includes/class-wpbdp.php
@@ -116,7 +116,7 @@ final class WPBDP {
 		self::translation_filters();
         add_filter( 'plugin_action_links_' . plugin_basename( WPBDP_PLUGIN_FILE ), array( $this, 'plugin_action_links' ) );
 
-        // Clear cache of page IDs when a page is saved.
+		// Clear cache of page IDs when a page is created, trashed, or saved.
         add_action( 'save_post_page', 'wpbdp_delete_page_ids_cache' );
 
         // AJAX actions.

--- a/includes/class-wpbdp.php
+++ b/includes/class-wpbdp.php
@@ -343,15 +343,13 @@ final class WPBDP {
     }
 
     private function load_textdomain() {
-        //        $languages_dir = str_replace( trailingslashit( WP_PLUGIN_DIR ), '', WPBDP_PATH . 'languages' );
-
         $languages_dir = trailingslashit( basename( WPBDP_PATH ) ) . 'languages';
         load_plugin_textdomain( 'business-directory-plugin', false, $languages_dir );
     }
 
     public function plugin_activation() {
 		add_action( 'shutdown', 'flush_rewrite_rules' );
-        delete_transient( 'wpbdp-page-ids' );
+		wpbdp_delete_page_ids_cache()
     }
 
     public function plugin_deactivation() {

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -39,12 +39,9 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
     } else {
         $query = 'SELECT ID';
     }
-	$query .= " FROM {$wpdb->posts} WHERE post_type = 'page' AND ( post_status = 'publish' OR post_status = 'private' ) AND ( 1=0";
 
-    foreach ( $shortcodes[ $page_id ] as $s ) {
-        $query .= sprintf( " OR post_content LIKE '%%[%s]%%' ", $s );
-    }
-    $query .= ')';
+	$query .= " FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status in ( 'publish', 'private' ) AND ";
+	$query .= $wpdb->prepare( 'post_content REGEXP %s', implode( '|', $shortcodes[ $page_id ] ) );
 
     return $query;
 }

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -34,9 +34,9 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
     }
 
     if ( $count ) {
-        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND ( 1=0";
+        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status != 'trash' AND ( 1=0";
     } else {
-        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND ( 1=0";
+        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status != 'trash' AND ( 1=0";
     }
 
     foreach ( $shortcodes[ $page_id ] as $s ) {

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -34,9 +34,9 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
     }
 
     if ( $count ) {
-        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status != 'trash' AND ( 1=0";
+        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status = 'publish' OR post_status = 'private' AND ( 1=0";
     } else {
-        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status != 'trash' AND ( 1=0";
+        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status = 'publish' OR post_status = 'private' AND ( 1=0";
     }
 
     foreach ( $shortcodes[ $page_id ] as $s ) {

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -112,8 +112,8 @@ function wpbdp_get_page_ids_with_query( $page_id ) {
         return null;
     }
 
-    $q .= ' ORDER BY ID ASC ';
-
+    $q .= ' ORDER BY ID, post_status ASC ';
+error_log( $q );
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
     return $wpdb->get_col( $q );
 }

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -34,9 +34,9 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
     }
 
     if ( $count ) {
-        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status = 'publish' OR post_status = 'private' AND ( 1=0";
+        $query = "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'page' AND ( post_status = 'publish' OR post_status = 'private' ) AND ( 1=0";
     } else {
-        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status = 'publish' OR post_status = 'private' AND ( 1=0";
+        $query = "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'page' AND ( post_status = 'publish' OR post_status = 'private' ) AND ( 1=0";
     }
 
     foreach ( $shortcodes[ $page_id ] as $s ) {

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -33,12 +33,12 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
         return false;
     }
 
-    if ( $count ) {
+	if ( $count ) {
 		_deprecated_argument( __FUNCTION__, '5.16.1', '$count is no longer supported' );
-        $query = 'SELECT COUNT(*)';
-    } else {
-        $query = 'SELECT ID';
-    }
+		$query = 'SELECT COUNT(*)';
+	} else {
+		$query = 'SELECT ID';
+	}
 
 	$query .= " FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status in ( 'publish', 'private' ) AND ";
 	$query .= $wpdb->prepare( 'post_content REGEXP %s', implode( '|', $shortcodes[ $page_id ] ) );

--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -34,6 +34,7 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
     }
 
     if ( $count ) {
+		_deprecated_argument( __FUNCTION__, '5.16.1', '$count is no longer supported' );
         $query = 'SELECT COUNT(*)';
     } else {
         $query = 'SELECT ID';

--- a/includes/installer.php
+++ b/includes/installer.php
@@ -43,7 +43,7 @@ class WPBDP_Installer {
 
         if ( $this->installed_version ) {
 			wpbdp_log( 'WPBDP is already installed.' );
-            return $this->_update();
+			$this->_update();
         } else if ( $this->_table_exists( "{$wpdb->prefix}wpbdp_form_fields" ) ) {
 			wpbdp_log( 'New installation. Creating default form fields.' );
             global $wpbdp;


### PR DESCRIPTION
Related issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5008

This clears the cache when a page with the `[businessdirectory]` is permanently deleted from the database
If a page has a status of `trash` and has the shortcode `[businessdirectory]`, this is excluded. Trash pages tend to have the `/?page_id=xxx` in the url and could bring issues when an old directory page is moved to trash to make way for another directory page (please advise if this is okay)