### PR TITLE
Allow themes to have a bd- prefix

### DIFF
--- a/includes/licensing.php
+++ b/includes/licensing.php
@@ -386,19 +386,23 @@ class WPBDP_Licensing {
      * Returns the license status from license information.
      */
     public function get_license_status( $license_key = '', $item_id = '', $item_type = 'module' ) {
-        if ( ! $license_key ) {
-            $license_key = wpbdp_get_option( 'license-key-' . $item_type . '-' . $item_id );
-        }
+		$data_key = $item_type . '-' . $item_id;
+		$no_prefix = $item_type . '-' . str_replace( 'bd-', '', $item_id );
+		if ( ! empty( $this->licenses[ $no_prefix ] ) ) {
+			// Allow for an extra 'bd-' on the theme folder name.
+			$data_key = $no_prefix;
+		}
 
-        if ( $license_key ) {
-            $data_key = $item_type . '-' . $item_id;
-            if ( ! empty( $this->licenses[ $data_key ] ) ) {
-                $data = $this->licenses[ $data_key ];
+		if ( ! $license_key ) {
+			$license_key = wpbdp_get_option( 'license-key-' . $data_key );
+		}
 
-                if ( ! empty( $data['license_key'] ) && $license_key == $data['license_key'] ) {
-                    return $data['status'];
-                }
-            }
+		if ( $license_key && ! empty( $this->licenses[ $data_key ] ) ) {
+			$data = $this->licenses[ $data_key ];
+
+			if ( ! empty( $data['license_key'] ) && $license_key == $data['license_key'] ) {
+				return $data['status'];
+			}
 		}
 
         return 'invalid';

--- a/includes/themes.php
+++ b/includes/themes.php
@@ -90,6 +90,9 @@ class WPBDP_Themes {
 			'wpbdp_themes__' . $theme_name . '_' . $fname,
 			'wpbdp_' . $theme_name . '_' . $fname,
 			$theme_name . '_' . $fname,
+
+			// Allow for themes with bd- prefix.
+			'wpbdp_themes__' . str_replace( 'bd_', '', $theme_name ) . '_' . $fname,
 		);
 
         foreach ( $alternatives as $alt ) {
@@ -379,9 +382,9 @@ class WPBDP_Themes {
 
         $manifest_file = $d . 'theme.json';
 
-        if ( ! is_readable( $manifest_file ) ) {
-            return false;
-        }
+		if ( ! is_readable( $manifest_file ) ) {
+			return false;
+		}
 
         $manifest = (array) json_decode( file_get_contents( $manifest_file ) );
         if ( ! $manifest ) {


### PR DESCRIPTION
This fixes https://github.com/Strategy11/bd-modern-filtered/issues/2

This would still be a problem if someone downloads the main Github zip file with the branch name in the folder. But I don't think it's worth spending dev time fixing that one.