### PR TITLE
Show error messages returned with a hook

### DIFF
--- a/includes/controllers/pages/class-submit-listing.php
+++ b/includes/controllers/pages/class-submit-listing.php
@@ -1048,6 +1048,7 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 
                 if ( ! $validate_res ) {
                     $validation_errors[ $field->get_id() ] = $field_errors;
+					$field->add_validation_error( $field_errors );
                 } else {
                     $field->store_value( $this->listing->get_id(), $value );
                 }

--- a/includes/fields/class-form-field.php
+++ b/includes/fields/class-form-field.php
@@ -529,6 +529,19 @@ class WPBDP_Form_Field {
         return $this->validation_errors;
     }
 
+	/**
+	 * @param array|string $error
+	 *
+	 * @since x.x
+	 */
+	public function add_validation_error( $error ) {
+		if ( is_array( $error ) ) {
+			$this->validation_errors = array_merge( $this->validation_errors, $error );
+		} else {
+			$this->validation_errors[] = $error;
+		}
+	}
+
     public function validate_categories( $categories = array() ) {
         $supported_cats = $this->data( 'supported_categories', 'all' );
         if ( 'all' === $supported_cats ) {


### PR DESCRIPTION
The wpbdp_listing_submit_validate_field hook already had a way to add error messages for a field. But the problem is that the error wouldn't show with the field.