### PR TITLE
Fix Field value filter

### DIFF
--- a/includes/fields/class-fieldtypes-textarea.php
+++ b/includes/fields/class-fieldtypes-textarea.php
@@ -317,7 +317,7 @@ class WPBDP_FieldTypes_TextArea extends WPBDP_Form_Field_Type {
     }
 
     public function get_field_html_value( &$field, $post_id ) {
-        $value = apply_filters( 'wpbdp_form_field_html_value', $field->value( $post_id ), $post_id, $field );
+		$value = apply_filters( 'wpbdp_form_field_html_value', $field->value( $post_id ), $post_id, $field, 'listing' );
 
 		$allowed_tags = self::allowed_html_tags( $field );
 


### PR DESCRIPTION
Fixes missing parameter in the `wpbdp_form_field_html_value` in the text area field type.
The filter requires 4 parameters but only 3 were present. This mainly affects using the filter in the Field Icons premium PR where the filter defined in https://github.com/Strategy11/business-directory-plugin/blob/816824cf4d96a4c53de71106ad73c54eda058f2e/includes/fields/class-form-field.php#L435 has 4 parameters