### PR TITLE
Fix issues with getting correct page for links

### DIFF
--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -41,7 +41,7 @@ function _wpbdp_page_lookup_query( $page_id, $count = false ) {
 	}
 
 	$query .= " FROM {$wpdb->posts} WHERE post_type = 'page' AND post_status in ( 'publish', 'private' ) AND ";
-	$query .= $wpdb->prepare( 'post_content REGEXP %s', implode( '|', $shortcodes[ $page_id ] ) );
+	$query .= $wpdb->prepare( 'post_content REGEXP %s', '\[' . implode( '\]|\[', $shortcodes[ $page_id ] ) );
 
     return $query;
 }
@@ -91,7 +91,7 @@ function wpbdp_get_page_ids_with_query( $page_id ) {
         return null;
     }
 
-	$q .= ' ORDER BY ID ASC ';
+	$q .= ' ORDER BY ID DESC ';
 
 	return WPBDP_Utils::check_cache(
 		array(


### PR DESCRIPTION
This is a continuation of https://github.com/Strategy11/business-directory-plugin/pull/96

It looks like too many pages were getting included in the page options, so it does need a check for the exact shortcode after all.

Also, I switched the order, so the most recent page with the url will be used. This means when someone creates a new page with the shortcode, that page will be used instead of the auto generated one.