### PR TITLE
Fee Plan Table Fix

### DIFF
--- a/includes/admin/helpers/tables/class-fees-table.php
+++ b/includes/admin/helpers/tables/class-fees-table.php
@@ -254,7 +254,7 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
 			return $column;
 		}
 
-		$revenue = wpbdp_currency_format( $fee->total_revenue() );
+		$revenue = wpbdp_currency_format( $fee->total_revenue(), array( 'force_numeric' => true ) );
 		$column .= ' <br/><span class="wpbdp-tag">' . esc_html( $revenue ) . '</span>';
 		return $column;
 	}

--- a/includes/models/class-fee-plan.php
+++ b/includes/models/class-fee-plan.php
@@ -305,7 +305,7 @@ final class WPBDP__Fee_Plan {
 
 		global $wpdb;
 
-		$query = $wpdb->prepare( "SELECT SUM(amount) FROM {$wpdb->prefix}wpbdp_payments p LEFT JOIN {$wpdb->prefix}wpbdp_listings l ON (l.listing_id = p.listing_id) WHERE p.status = %s AND l.fee_id = %d", 'completed', $this->id );
+		$query = $wpdb->prepare( "SELECT SUM(amount) FROM {$wpdb->prefix}wpbdp_payments p LEFT JOIN {$wpdb->prefix}wpbdp_listings l ON (l.listing_id = p.listing_id) WHERE p.status = %s AND l.fee_id = %d AND l.flags != %s", 'completed', $this->id, 'admin-posted' );
 		$total = WPBDP_Utils::check_cache(
 			array(
 				'cache_key' => 'payments_complete_plan_' . $this->id,


### PR DESCRIPTION
Related issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5015

This fixes the `Listings` column in the `Fee Plans` Table. Reported issues were :

- Admin submitted paid listings would count towards the total. This would give a false total count of the revenue the specific plan collected
- A listing created with a 100% discount would show the total as `free` and not `0.00`. This would only happen if there is one listing of such type with the paid plan. If there are more than one listings, the total count shows correctly.

![image](https://user-images.githubusercontent.com/121492/149159368-146cfa9f-8334-46f5-8699-3e1af23c9e27.png)


Expected view after changes

![image](https://user-images.githubusercontent.com/121492/149159283-d866c8f0-dead-436b-ad17-e052268c4115.png)
 