### PR TITLE
Field Wrapper adjustments

### DIFF
--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -426,13 +426,14 @@ class WPBDP_Form_Field_Type {
 
         $html  = '';
         $tag_attrs = isset( $args['tag_attrs'] ) ? self::html_attributes( $args['tag_attrs'] ) : '';
+		$atts = array();
+		if ( is_object( $labelorfield ) ) {
+			$atts['field'] = $labelorfield;
+		}
+		$extra_classes = apply_filters( 'wpbdp_display_field_wrapper_classes', $extra_classes, $atts );
 		$html .= '<div class="' . esc_attr( $css_classes . ' ' . $extra_classes ) . '" ' . $tag_attrs . '>';
 
 		if ( $label ) {
-			$atts = array();
-			if ( is_object( $labelorfield ) ) {
-				$atts['field'] = $labelorfield;
-			}
 			$html .= self::field_label_display_wrapper( $label, $atts );
 		}
 


### PR DESCRIPTION
https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5016

Add extra class filter `wpbdp_display_field_wrapper_classes` to allow adding of extra classes to the field wrapper.

The filter is being used in this line https://github.com/Strategy11/business-directory-premium/blob/6038eab51e7927e4de33136a3ffd8a495315e51a/classes/class-wpbdp-field-icon.php#L23 to include an extra class in the wrapper. 
Added an extra class to hide the label if the value is to be used as an icon only
End result is as follows 

![image](https://user-images.githubusercontent.com/121492/149195106-9aeda8d4-b9e9-4006-bad2-7eee521be681.png)
