### PR TITLE
Hide the list-actions div if there are no buttons in it

### DIFF
--- a/templates/parts/listing-buttons.tpl.php
+++ b/templates/parts/listing-buttons.tpl.php
@@ -6,9 +6,7 @@
  */
 
 $buttons = '';
-?>
-<div class="listing-actions cf">
-<?php
+
 if ( 'single' === $view ) :
     if ( wpbdp_user_can( 'edit', $listing_id ) ) :
 		$buttons .= sprintf(
@@ -69,7 +67,14 @@ elseif ( 'excerpt' === $view ) :
     endif;
 endif;
 
-// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo apply_filters( 'wpbdp-listing-buttons', $buttons, $listing_id );
+$buttons = apply_filters( 'wpbdp-listing-buttons', $buttons, $listing_id );
+if ( ! $buttons ) {
+	return;
+}
 ?>
+<div class="listing-actions cf">
+	<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo $buttons;
+	?>
 </div>


### PR DESCRIPTION
If there were no buttons, the empty div was still included on the page.

This is changed for two reasons:
1. It's just extra html that isn't needed
2. It adds extra space in a flex layout when it shouldn't. Here's the end result without it: https://github.com/Strategy11/bd-business-card/pull/3#issuecomment-1012413752