### PR TITLE
Dont show notice if modules are active in free version

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -767,7 +767,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
 			$modules = wpbdp()->modules;
 
-			if ( $modules->is_loaded( 'premium' ) || $modules->is_loaded( 'paypal' ) || $modules->is_loaded( 'googlemaps' ) ) {
+			if ( $modules->is_loaded( 'premium' ) || count( array_keys( $modules->get_modules() ) ) > 0 ) {
 				return;
 			}
 			?>

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -767,7 +767,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
 			$modules = wpbdp()->modules;
 			$module_count = $this->get_installed_premium_module_count( $modules );
-			if ( $modules->is_loaded( 'premium' ) || $module_count > 0 ) {
+			if ( $module_count > 0 ) {
 				return;
 			}
 			?>

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -766,8 +766,8 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			}
 
 			$modules = wpbdp()->modules;
-
-			if ( $modules->is_loaded( 'premium' ) || count( array_keys( $modules->get_modules() ) ) > 0 ) {
+			$module_count = $this->get_installed_premium_module_count( $modules );
+			if ( $modules->is_loaded( 'premium' ) || $module_count > 0 ) {
 				return;
 			}
 			?>
@@ -778,6 +778,21 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 				</a>
 			</div>
 			<?php
+		}
+
+		/**
+		 * Get the installed premium modules count.
+		 *
+		 * @since x.x
+		 *
+		 * @return int
+		 */
+		private function get_installed_premium_module_count( $modules ) {
+			$module_list = $modules->get_modules();
+			if ( isset( $module_list['categories'] ) ) {
+				unset( $module_list['categories'] );
+			}
+			return count( array_keys( $module_list ) );
 		}
 
         function handle_actions() {


### PR DESCRIPTION
This disables the notice when one of the BD modules is activated with a valid license.
Before:

![image](https://user-images.githubusercontent.com/121492/149890545-a4fcff38-5720-4447-824d-dcb4a7a4381d.png)

After:

![image](https://user-images.githubusercontent.com/121492/149890907-b91918fd-54fa-436f-bbaa-a3c23e6e446f.png)
![image](https://user-images.githubusercontent.com/121492/149890934-889364fe-b031-408e-b1d0-ea64533e2126.png)
