### PR TITLE
Import file extension convert to lowercase

### DIFF
--- a/includes/admin/csv-import.php
+++ b/includes/admin/csv-import.php
@@ -440,7 +440,7 @@ class WPBDP_CSVImportAdmin {
 			'csv'    => 'csv',
 		);
 
-		$uploaded_type = pathinfo( $filename, PATHINFO_EXTENSION );
+		$uploaded_type = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
 		return $uploaded_type === $allowed_type[ $type ];
 	}
 


### PR DESCRIPTION
Related issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5024

Currently if an import is uploaded with the `.csv` in uppercase as `.CSV` the error returns that it is an invalid format. This fix sets the extension to lower case to avoid case-sensitive validation of files uploaded