### PR TITLE
Proper handling of removing images

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,7 @@ module.exports = function( grunt ) {
         src: [
 			'**/*', '!**/*~', '!**/**.less', '!**/tests/**', '!**/**/less',
 			'!**/.*', '!**/phpcs.xml', '!**/phpunit.xml', '!**/composer.json',
+			'!**/package.json', '!**/package-lock.json', '!**/node_modules/**',
 			'!**/*.md', '!**/*.yml'
 		]
       } );

--- a/includes/admin/class-listing-fields-metabox.php
+++ b/includes/admin/class-listing-fields-metabox.php
@@ -59,7 +59,7 @@ class WPBDP_Admin_Listing_Fields_Metabox {
             return;
         }
 
-        $images       = $this->listing->get_images( 'all', true );
+        $images       = $this->listing->get_images( 'all', false );
         $thumbnail_id = $this->listing->get_thumbnail_id();
 
         echo '<div class="wpbdp-submit-listing-section-listing_images">';

--- a/includes/helpers/class-listing-image.php
+++ b/includes/helpers/class-listing-image.php
@@ -132,7 +132,6 @@ final class WPBDP_Listing_Image {
 			// Attach to the next listing.
 			self::set_post_parent( $id, reset( $linked_listings ) );
 			clean_post_cache( $id );
-			clean_post_cache( $listing_id );
 		}
 		$post_thumbnail_id = get_post_thumbnail_id( $listing_id );
 		if ( $post_thumbnail_id === $id ) {

--- a/includes/helpers/class-listing-image.php
+++ b/includes/helpers/class-listing-image.php
@@ -101,7 +101,7 @@ final class WPBDP_Listing_Image {
 		wp_update_post(
 			array(
 				'ID'          => $id,
-				'post_parent' => ''
+				'post_parent' => 0
 			)
 		);
 	}
@@ -131,6 +131,12 @@ final class WPBDP_Listing_Image {
 		} else {
 			// Attach to the next listing.
 			self::set_post_parent( $id, reset( $linked_listings ) );
+			clean_post_cache( $id );
+			clean_post_cache( $listing_id );
+		}
+		$post_thumbnail_id = get_post_thumbnail_id( $listing_id );
+		if ( $post_thumbnail_id === $id ) {
+			delete_post_thumbnail( $listing_id );
 		}
 	}
 }

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -161,6 +161,7 @@ class WPBDP_Listing {
 
 		update_post_meta( $this->id, '_wpbdp[images]', $keep_images );
 		WPBDP_Utils::cache_delete_group( 'wpbdp_listings' );
+        clean_post_cache( $this->id );
 	}
 
 	public function set_thumbnail_id( $image_id ) {

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -161,7 +161,7 @@ class WPBDP_Listing {
 
 		update_post_meta( $this->id, '_wpbdp[images]', $keep_images );
 		WPBDP_Utils::cache_delete_group( 'wpbdp_listings' );
-        clean_post_cache( $this->id );
+		clean_post_cache( $this->id );
 	}
 
 	public function set_thumbnail_id( $image_id ) {


### PR DESCRIPTION
Issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5014

There was an issue where different listings sharing images would not delete the images. This would mainly happen if the first shared image is the same shares the same attachment id.
During the fix process, I noticed the attachment cache was not cleared, and remained with the listing, also the re-arrange function in the frontend would get an attachment object instead of a listing object. This resulted in a broken image display of a non-existent image. 

Using the function `clean_post_cache` thhe cache is cleared and there is also an extra check if the selected image is the thumbnail to also exclude it and get a fresh image from the list.
