### PR TITLE
Remove file object sanitization in controller

### DIFF
--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -768,7 +768,6 @@ foreach ( $value as $i => $notice ) {
         if ( isset( $_FILES['file']['error'] ) && $_FILES['file']['error'] == 0 ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$file = wp_unslash( $_FILES['file'] );
-			wpbdp_sanitize_value( 'sanitize_text_field', $file );
             // TODO: we support only images for now but we could use this for anything later
 			$media_id = wpbdp_media_upload(
                 $file,


### PR DESCRIPTION
Related issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5027

Similar sanitization issue as https://github.com/Strategy11/business-directory-plugin/pull/116
This removes the array sanitization of the file object