### PR TITLE
Allow enable and disable of default plan

### DIFF
--- a/includes/admin/helpers/tables/class-fees-table.php
+++ b/includes/admin/helpers/tables/class-fees-table.php
@@ -145,21 +145,20 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
 			$admin_fees_url
 		);
 
+		if ( $fee->enabled ) {
+			$actions['disable'] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $toggle_url ),
+				esc_html__( 'Disable', 'business-directory-plugin' )
+			);
+		} else {
+			$actions['enable'] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $toggle_url ),
+				esc_html__( 'Enable', 'business-directory-plugin' )
+			);
+		}
 		if ( 'free' !== $fee->tag ) {
-			if ( $fee->enabled ) {
-				$actions['disable'] = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( $toggle_url ),
-					esc_html__( 'Disable', 'business-directory-plugin' )
-				);
-			} else {
-				$actions['enable'] = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( $toggle_url ),
-					esc_html__( 'Enable', 'business-directory-plugin' )
-				);
-			}
-
             $actions['delete'] = sprintf(
                 '<a href="%s">%s</a>',
                 esc_url(


### PR DESCRIPTION
Related to https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5031

Current functionality:
- Default plan only gets enabled if there is no payment gateway active. 
- If there is a payment active, it is set to disabled to only allow paid plans to show in the frontend


New functionality:
- Default plan can be enabled or disabled regardless of payment plan state
- If there is payment gateway enabled, the default plan will not be visible in the frontend
- If there is no payment gateway available and the default plan is active, it will show in the frontend
- If there is no payment gateway available and the default plan is disabled, it will not show in the frontend
