### PR TITLE
Only delete image if not attached to another post

### DIFF
--- a/includes/helpers/class-listing-image.php
+++ b/includes/helpers/class-listing-image.php
@@ -125,8 +125,9 @@ final class WPBDP_Listing_Image {
 
 		// If the current listing is still cached, don't count it.
 		$linked_listings = array_diff( $linked_listings, array( $listing_id ) );
-
-		if ( empty( $linked_listings ) ) {
+		$linked_posts    = self::get_linked_posts( $id );
+		$linked_posts    = array_diff( $linked_posts, array( $listing_id ) );
+		if ( empty( $linked_listings ) && empty( $linked_posts ) ) {
 			wp_delete_attachment( $id, true );
 		} else {
 			// Attach to the next listing.
@@ -137,5 +138,27 @@ final class WPBDP_Listing_Image {
 		if ( $post_thumbnail_id === $id ) {
 			delete_post_thumbnail( $listing_id );
 		}
+	}
+
+	/**
+	 * Checks id an attachment is linked to other posts.
+	 * This checks if the attachment is in use with other posts and returns the ids.
+	 *
+	 * @param int $attachment_id The attachment id.
+	 *
+	 * @since x.x
+	 *
+	 * @return array
+	 */
+	public static function get_linked_posts( $attachment_id ) {
+		global $wpdb;
+		$linked_posts = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT post_id FROM ' . $wpdb->postmeta . ' WHERE meta_key= %s AND meta_value = %s',
+				'_thumbnail_id',
+				absint( $attachment_id )
+			)
+		);
+		return $linked_posts;
 	}
 }


### PR DESCRIPTION
Related issue https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5034

Before images linked to other posts or pages would be deleted which is something we do not want. 
This fix checks if the attachment is linked to a post via the post meta name `_thumbnail_id` . If there is another post linked to the image, it will not be deleted. It is not currently possible to check for images added in a post body as they are not recorded in the post_meta table.