### PR TITLE
Feature : Add category parameter to featured listing shortcode

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -317,7 +317,7 @@ class WPBDP__Shortcodes {
         $query_args = array();
         $query_args['items_per_page'] = intval( $sc_atts['items_per_page'] );
 
-		$query_args = $this->process_category_atts( $sc_atts, $query_args );
+		$this->process_category_atts( $sc_atts, $query_args );
 
         if ( $sc_atts['tag'] || $sc_atts['tags'] ) {
             $requested_tags = array();
@@ -428,7 +428,7 @@ class WPBDP__Shortcodes {
 			'post__in' => ! empty( $featured ) ? $featured : array( 0 ),
 			'orderby'  => 'post__in',
 		);
-		$query_args = $this->process_category_atts( $sc_atts, $query_args );
+		$this->process_category_atts( $sc_atts, $query_args );
         return $this->display_listings(
 			$query_args,
             $sc_atts
@@ -442,44 +442,46 @@ class WPBDP__Shortcodes {
 	 * @param array $query_args The query args used to search based on attributes.
 	 *
 	 * @since x.x
-	 *
-	 * @return array $query_args
 	 */
-	private function process_category_atts( $atts, $query_args ) {
-		if ( isset( $atts['category'] ) || isset( $atts['categories'] ) ) {
-			$requested_categories = array();
+	private function process_category_atts( $atts, &$query_args ) {
+		if ( ! isset( $atts['category'] ) && ! isset( $atts['categories'] ) ) {
+			return;
+		}
 
-			if ( isset( $atts['category'] ) )
-				$requested_categories = array_merge( $requested_categories, explode( ',', $atts['category'] ) );
+		$requested_categories = array();
 
-			if ( isset( $atts['categories'] ) )
-				$requested_categories = array_merge( $requested_categories, explode( ',', $atts['categories'] ) );
+		if ( isset( $atts['category'] ) ) {
+			$requested_categories = array_merge( $requested_categories, explode( ',', $atts['category'] ) );
+		}
 
-			$categories = array();
+		if ( isset( $atts['categories'] ) ) {
+			$requested_categories = array_merge( $requested_categories, explode( ',', $atts['categories'] ) );
+		}
 
-			foreach ( $requested_categories as $cat ) {
-				$term = null;
-				if ( ! is_numeric( $cat ) ) {
-					$term = get_term_by( 'slug', $cat, WPBDP_CATEGORY_TAX );
-				}
+		$categories = array();
 
-				if ( ! $term && is_numeric( $cat ) ) {
-					$term = get_term_by( 'id', $cat, WPBDP_CATEGORY_TAX );
-				}
-
-				if ( $term )
-					$categories[] = $term->term_id;
+		foreach ( $requested_categories as $cat ) {
+			$term = null;
+			if ( ! is_numeric( $cat ) ) {
+				$term = get_term_by( 'slug', $cat, WPBDP_CATEGORY_TAX );
 			}
 
-			$query_args['tax_query'][] = array(
-				array(
-					'taxonomy' => WPBDP_CATEGORY_TAX,
-					'field'    => 'id',
-					'terms'    => $categories,
-				)
-			);
+			if ( ! $term && is_numeric( $cat ) ) {
+				$term = get_term_by( 'id', $cat, WPBDP_CATEGORY_TAX );
+			}
+
+			if ( $term ) {
+				$categories[] = $term->term_id;
+			}
 		}
-		return $query_args;
+
+		$query_args['tax_query'][] = array(
+			array(
+				'taxonomy' => WPBDP_CATEGORY_TAX,
+				'field'    => 'id',
+				'terms'    => $categories,
+			)
+		);
 	}
 
     private function display_listings( $query_args, $args = array() ) {

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -317,35 +317,7 @@ class WPBDP__Shortcodes {
         $query_args = array();
         $query_args['items_per_page'] = intval( $sc_atts['items_per_page'] );
 
-        if ( $sc_atts['category'] || $sc_atts['categories'] ) {
-            $requested_categories = array();
-
-            if ( $sc_atts['category'] )
-                $requested_categories = array_merge( $requested_categories, explode( ',', $sc_atts['category'] ) );
-
-            if ( $sc_atts['categories'] )
-                $requested_categories = array_merge( $requested_categories, explode( ',', $sc_atts['categories'] ) );
-
-            $categories = array();
-
-            foreach ( $requested_categories as $cat ) {
-                $term = null;
-				if ( ! is_numeric( $cat ) ) {
-					$term = get_term_by( 'slug', $cat, WPBDP_CATEGORY_TAX );
-				}
-
-				if ( ! $term && is_numeric( $cat ) ) {
-					$term = get_term_by( 'id', $cat, WPBDP_CATEGORY_TAX );
-				}
-
-                if ( $term )
-                    $categories[] = $term->term_id;
-            }
-
-            $query_args['tax_query'][] = array( array( 'taxonomy' => WPBDP_CATEGORY_TAX,
-                                                     'field' => 'id',
-                                                     'terms' => $categories ) );
-        }
+		$query_args = $this->process_category_atts( $sc_atts, $query_args );
 
         if ( $sc_atts['tag'] || $sc_atts['tags'] ) {
             $requested_tags = array();
@@ -456,8 +428,32 @@ class WPBDP__Shortcodes {
 			'post__in' => ! empty( $featured ) ? $featured : array( 0 ),
 			'orderby'  => 'post__in',
 		);
-		if ( $sc_atts['category'] ) {
-			$requested_categories = explode( ',', $sc_atts['category'] );
+		$query_args = $this->process_category_atts( $sc_atts, $query_args );
+        return $this->display_listings(
+			$query_args,
+            $sc_atts
+        );
+    }
+
+	/**
+	 * Process category query attributes.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @param array $query_args The query args used to search based on attributes.
+	 *
+	 * @since x.x
+	 *
+	 * @return array $query_args
+	 */
+	private function process_category_atts( $atts, $query_args ) {
+		if ( isset( $atts['category'] ) || isset( $atts['categories'] ) ) {
+			$requested_categories = array();
+
+			if ( isset( $atts['category'] ) )
+				$requested_categories = array_merge( $requested_categories, explode( ',', $atts['category'] ) );
+
+			if ( isset( $atts['categories'] ) )
+				$requested_categories = array_merge( $requested_categories, explode( ',', $atts['categories'] ) );
 
 			$categories = array();
 
@@ -483,11 +479,8 @@ class WPBDP__Shortcodes {
 				)
 			);
 		}
-        return $this->display_listings(
-			$query_args,
-            $sc_atts
-        );
-    }
+		return $query_args;
+	}
 
     private function display_listings( $query_args, $args = array() ) {
         $query_args = array_merge(


### PR DESCRIPTION
Related feature : https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5036

This adds the attribute `category` to the shortcode `[businessdirectory-featured-listings]`  to allow featured listings to be shown by category. For example `[businessdirectory-featured-listings category='casino']` or `[businessdirectory-featured-listings category='casino,post']` for multiple categories. The category attribute functions the same as the other category attributes in `[businessdirectory-listings]` shortcode.