### PR TITLE
Edit Listing Fee Plan Error Message

### DIFF
--- a/includes/admin/controllers/class-admin-fees.php
+++ b/includes/admin/controllers/class-admin-fees.php
@@ -112,11 +112,11 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 
 		if ( ! is_wp_error( $result ) ) {
 			if ( 'insert' === $mode ) {
-				wpbdp_admin_message( __( 'Fee plan added.', 'business-directory-plugin' ) );
+				wpbdp_admin_message( __( 'Plan added.', 'business-directory-plugin' ) );
 			} elseif ( $images_changed ) {
 				$this->show_update_listing_msg( $fee );
 			} else {
-				wpbdp_admin_message( __( 'Fee plan updated.', 'business-directory-plugin' ) );
+				wpbdp_admin_message( __( 'Plan updated.', 'business-directory-plugin' ) );
 			}
 		} else {
 			foreach ( $result->get_error_messages() as $msg ) {
@@ -131,7 +131,7 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 	 * @since 5.15.3
 	 */
 	private function show_update_listing_msg( $fee ) {
-		$message = __( 'Fee plan updated.', 'business-directory-plugin' );
+		$message = __( 'Plan updated.', 'business-directory-plugin' );
 
 		$total_listings = $fee->count_listings();
 		if ( ! $total_listings ) {
@@ -173,11 +173,11 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 		$fee     = wpbdp_get_fee_plan( $plan_id );
 		$res     = new WPBDP_Ajax_Response();
 		if ( ! $fee ) {
-			$res->send_error( __( 'Fee plan not found.', 'business-directory-plugin' ) );
+			$res->send_error( __( 'Plan not found.', 'business-directory-plugin' ) );
 		}
 
 		$this->update_listing_images( $fee );
-		$res->set_message( __( 'Fee plan listings updated.', 'business-directory-plugin' ) );
+		$res->set_message( __( 'Plan listings updated.', 'business-directory-plugin' ) );
 		$res->send();
 	}
 

--- a/includes/admin/controllers/class-admin-fees.php
+++ b/includes/admin/controllers/class-admin-fees.php
@@ -251,9 +251,14 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 
     function toggle_fee() {
 		$fee = $this->get_or_die();
-        $fee->enabled = ! $fee->enabled;
-        $fee->save();
-		wpbdp_admin_message( $fee->enabled ? _x( 'Fee enabled.', 'fees admin', 'business-directory-plugin' ) : _x( 'Fee disabled.', 'fees admin', 'business-directory-plugin' ) );
+		$enabled_plans = WPBDP_Fees_API::has_enabled_plans();
+		if ( $enabled_plans > 1 || ! $fee->enabled ) {
+			$fee->enabled = ! $fee->enabled;
+			$fee->save();
+			wpbdp_admin_message( $fee->enabled ? _x( 'Fee enabled.', 'fees admin', 'business-directory-plugin' ) : _x( 'Fee disabled.', 'fees admin', 'business-directory-plugin' ) );
+		} else {
+			wpbdp_admin_message( __( 'Cannot disable fee plan. At least one fee plan should be enabled', 'business-directory-plugin' ), 'error' );
+		}
         return $this->_redirect( 'index' );
     }
 

--- a/includes/admin/controllers/class-admin-fees.php
+++ b/includes/admin/controllers/class-admin-fees.php
@@ -242,7 +242,7 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
         ) );
 
         if ( $do && $fee->delete() ) {
-            wpbdp_admin_message( sprintf( _x( 'Fee "%s" deleted.', 'fees admin', 'business-directory-plugin' ), $fee->label ) );
+            wpbdp_admin_message( sprintf( _x( 'Plan "%s" deleted.', 'fees admin', 'business-directory-plugin' ), $fee->label ) );
             return $this->_redirect( 'index' );
         }
 
@@ -251,13 +251,13 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 
     function toggle_fee() {
 		$fee = $this->get_or_die();
-		$enabled_plans = WPBDP_Fees_API::has_enabled_plans();
+		$enabled_plans = WPBDP_Fees_API::get_enabled_plans();
 		if ( $enabled_plans > 1 || ! $fee->enabled ) {
 			$fee->enabled = ! $fee->enabled;
 			$fee->save();
-			wpbdp_admin_message( $fee->enabled ? _x( 'Fee enabled.', 'fees admin', 'business-directory-plugin' ) : _x( 'Fee disabled.', 'fees admin', 'business-directory-plugin' ) );
+			wpbdp_admin_message( $fee->enabled ? _x( 'Plan enabled.', 'fees admin', 'business-directory-plugin' ) : _x( 'Plan disabled.', 'fees admin', 'business-directory-plugin' ) );
 		} else {
-			wpbdp_admin_message( __( 'Cannot disable fee plan. At least one fee plan should be enabled', 'business-directory-plugin' ), 'error' );
+			wpbdp_admin_message( __( 'Cannot disable plan. At least one plan should be enabled', 'business-directory-plugin' ), 'error' );
 		}
         return $this->_redirect( 'index' );
     }

--- a/includes/class-fees-api.php
+++ b/includes/class-fees-api.php
@@ -55,16 +55,7 @@ class WPBDP_Fees_API {
 	 * @return bool
 	 */
 	public static function has_paid_plans() {
-		global $wpdb;
-		$query   = "SELECT count(*) FROM {$wpdb->prefix}wpbdp_plans WHERE enabled != 0 AND amount > 0";
-		$total   = WPBDP_Utils::check_cache(
-			array(
-				'cache_key' => 'paid_plan_count',
-				'group'     => 'wpbdp_plans',
-				'query'     => $query,
-				'type'      => 'get_var',
-			)
-		);
+		$total = self::get_enabled_plans( true );
 		return $total > 0;
 	}
 
@@ -73,16 +64,23 @@ class WPBDP_Fees_API {
 	 * Check if there are enabled plans.
 	 * This does a count for all enabled plans regardless of the amount.
 	 *
+	 * @param bool $paid Return paid plans or all plans. Set to true to check for plans that have a price greater than 0
+	 *
 	 * @since x.x
 	 *
 	 * @return bool
 	 */
-	public static function has_enabled_plans() {
+	public static function get_enabled_plans( $paid = false ) {
 		global $wpdb;
-		$query   = "SELECT count(*) FROM {$wpdb->prefix}wpbdp_plans WHERE enabled != 0";
-		$total   = WPBDP_Utils::check_cache(
+		$query     = "SELECT count(*) FROM {$wpdb->prefix}wpbdp_plans WHERE enabled != 0";
+		$cache_key = 'enabled_plan_count';
+		if ( $paid ) {
+			$cache_key = 'paid_plan_count';
+			$query     .= ' AND amount > 0';
+		}
+		$total = WPBDP_Utils::check_cache(
 			array(
-				'cache_key' => 'enabled_plan_count',
+				'cache_key' => $cache_key,
 				'group'     => 'wpbdp_plans',
 				'query'     => $query,
 				'type'      => 'get_var',

--- a/includes/class-fees-api.php
+++ b/includes/class-fees-api.php
@@ -68,6 +68,29 @@ class WPBDP_Fees_API {
 		return $total > 0;
 	}
 
+
+    /**
+	 * Check if there are enabled plans.
+	 * This does a count for all enabled plans regardless of the amount.
+	 *
+	 * @since x.x
+	 *
+	 * @return bool
+	 */
+	public static function has_enabled_plans() {
+		global $wpdb;
+		$query   = "SELECT count(*) FROM {$wpdb->prefix}wpbdp_plans WHERE enabled != 0";
+		$total   = WPBDP_Utils::check_cache(
+			array(
+				'cache_key' => 'enabled_plan_count',
+				'group'     => 'wpbdp_plans',
+				'query'     => $query,
+				'type'      => 'get_var',
+			)
+		);
+		return $total;
+	}
+
     /**
      * @deprecated since 3.7.
      */

--- a/includes/controllers/pages/class-submit-listing.php
+++ b/includes/controllers/pages/class-submit-listing.php
@@ -891,7 +891,7 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
             if ( ! $plan || ! $plan->enabled || ! $plan->supports_category_selection( $categories ) ) {
                 if ( $this->editing ) {
 					if ( ! $plan->enabled ) {
-						$this->messages( _x( 'Current fee plan is disabled. Please select another fee plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+						$this->messages( _x( 'Current active fee plan is disabled. Please select another fee plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
 					} else {
 						$this->messages( _x( 'Please choose a valid category for your plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
 					}

--- a/includes/controllers/pages/class-submit-listing.php
+++ b/includes/controllers/pages/class-submit-listing.php
@@ -890,7 +890,11 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 
             if ( ! $plan || ! $plan->enabled || ! $plan->supports_category_selection( $categories ) ) {
                 if ( $this->editing ) {
-                    $this->messages( _x( 'Please choose a valid category for your plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+					if ( ! $plan->enabled ) {
+						$this->messages( _x( 'Current fee plan is disabled. Please select another fee plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+					} else {
+						$this->messages( _x( 'Please choose a valid category for your plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+					}
                 } else {
                     $this->messages( _x( 'Please choose a valid fee plan for your category selection.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
                 }

--- a/includes/controllers/pages/class-submit-listing.php
+++ b/includes/controllers/pages/class-submit-listing.php
@@ -884,19 +884,19 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 
             $this->prevent_save = true;
 		} elseif ( $categories && ! $plan_id ) {
-			$this->messages( __( 'Please choose a fee plan.', 'business-directory-plugin' ), 'error', 'plan_selection' );
+			$this->messages( __( 'Please choose a plan.', 'business-directory-plugin' ), 'error', 'plan_selection' );
         } elseif ( $categories && $plan_id ) {
             $plan = wpbdp_get_fee_plan( $plan_id );
 
             if ( ! $plan || ! $plan->enabled || ! $plan->supports_category_selection( $categories ) ) {
                 if ( $this->editing ) {
 					if ( ! $plan->enabled ) {
-						$this->messages( _x( 'Current active fee plan is disabled. Please select another fee plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+						$this->messages( _x( 'Current active plan is disabled. Please select another plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
 					} else {
 						$this->messages( _x( 'Please choose a valid category for your plan.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
 					}
                 } else {
-                    $this->messages( _x( 'Please choose a valid fee plan for your category selection.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
+                    $this->messages( _x( 'Please choose a valid plan for your category selection.', 'submit listing', 'business-directory-plugin' ), 'error', 'plan_selection' );
                 }
 
                 $this->prevent_save = true;


### PR DESCRIPTION
Reported issue : https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5033

This is a special case that should happen in a very rare occasion. Steps to reproduce

- Create a listing that has a premium plan assigned to it and publish it
- Edit the Fee plans and disable all plans and gateways
- Proceed to edit listing and an error message will show. Previous message was : `"Please choose a valid category for your plan."` . New message is : `"Current active fee plan is disabled. Please select another fee plan."` (may need better wording)

A better option would be to show a message on load or disable the "Next" button for a listing that fits the above criteria

![image](https://user-images.githubusercontent.com/121492/153844549-88ff6443-a9a8-4e99-aa7c-047b22dc22a3.png)

![image](https://user-images.githubusercontent.com/121492/153844570-6a4546b2-521e-40a5-8e17-7a109cefdcb9.png)

