### PR TITLE
Plan table string updates

### DIFF
--- a/includes/admin/helpers/tables/class-fees-table.php
+++ b/includes/admin/helpers/tables/class-fees-table.php
@@ -184,7 +184,7 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
 			__( 'ID: %s', 'business-directory-plugin' ),
 			$fee->id
 		);
-		$fee_id_string .= '<br/><strong>' . $fee->get_plan_type() . '</strong>';
+		$fee_id_string .= '<br/><strong>' . ( $fee->is_paid_plan() ? __( 'Paid Plan', 'business-directory-plugin' ) : __( 'Free Plan', 'business-directory-plugin' ) ) . '</strong>';
 
         $html .= sprintf(
             '<strong><a href="%s">%s</a></strong><br/>%s',

--- a/includes/admin/helpers/tables/class-fees-table.php
+++ b/includes/admin/helpers/tables/class-fees-table.php
@@ -184,7 +184,7 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
 			__( 'ID: %s', 'business-directory-plugin' ),
 			$fee->id
 		);
-		$fee_id_string .= '<br/><strong>' . ( $fee->amount > 0.0 ? __( 'Paid Plan', 'business-directory-plugin' ) : __( 'Free Plan', 'business-directory-plugin' ) ) . '</strong>';
+		$fee_id_string .= '<br/><strong>' . $fee->get_plan_type() . '</strong>';
 
         $html .= sprintf(
             '<strong><a href="%s">%s</a></strong><br/>%s',

--- a/includes/models/class-fee-plan.php
+++ b/includes/models/class-fee-plan.php
@@ -324,14 +324,11 @@ final class WPBDP__Fee_Plan {
 	 *
 	 * @since x.x
 	 *
-	 * @return string
+	 * @return bool
 	 */
-	public function get_plan_type() {
+	public function is_paid_plan() {
 		$is_variable = ( 'variable' === $this->pricing_model && array_sum( $this->pricing_details ) > 0 );
-		if ( $is_variable || $this->amount > 0.0 ) {
-			return __( 'Paid Plan', 'business-directory-plugin' );
-		}
-		return __( 'Free Plan', 'business-directory-plugin' );
+		return ( $is_variable || $this->amount > 0.0 );
 	}
 
     private function setup_plan( $data ) {

--- a/includes/models/class-fee-plan.php
+++ b/includes/models/class-fee-plan.php
@@ -317,6 +317,23 @@ final class WPBDP__Fee_Plan {
 		return $total;
 	}
 
+	/**
+	 * Get the plan type.
+	 * This checks if the amount of the plan has been set or the pricing type.
+	 * For variable plans, we check and ensure the price total is greater than 0 to classify as paid.
+	 *
+	 * @since x.x
+	 *
+	 * @return string
+	 */
+	public function get_plan_type() {
+		$is_variable = ( 'variable' === $this->pricing_model && array_sum( $this->pricing_details ) > 0 );
+		if ( $is_variable || $this->amount > 0.0 ) {
+			return __( 'Paid Plan', 'business-directory-plugin' );
+		}
+		return __( 'Free Plan', 'business-directory-plugin' );
+	}
+
     private function setup_plan( $data ) {
         if ( is_object( $data ) ) {
             $data = get_object_vars( $data );


### PR DESCRIPTION
Related issue : https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5048
Add check for variable plan to ensure that the correct plan text is shown if paid or free.

To replicate on current version:

- Create a variable fee plan
- Add an amount on the category selection
- Save and view on the admin plan list
- Plan will show as "Free"

![image](https://user-images.githubusercontent.com/121492/156039669-064aa9f3-b597-4e95-bd20-899fd479d052.png)
![image](https://user-images.githubusercontent.com/121492/156039701-6fc5c78d-846d-47a2-8d99-51f93b1a3dae.png)

Same plan with changes in PR:

- Text shows as "Paid plan"
- Text will only show "Paid Plan" if total amount is greater than 0

![image](https://user-images.githubusercontent.com/121492/156039766-af7e50ea-a7c0-4f31-94d0-7172199f273f.png)
