### PR TITLE
Disable listing date edit when it has a subscription

### DIFF
--- a/includes/models/class-listing-subscription.php
+++ b/includes/models/class-listing-subscription.php
@@ -158,7 +158,7 @@ class WPBDP__Listing_Subscription {
             ),
             array( 'listing_id' => $this->listing_id )
         );
-
+		WPBDP_Utils::cache_delete_group( 'wpbdp_listings' );
         do_action( 'wpbdp_listing_subscription_canceled', $this->listing_id );
     }
 
@@ -174,7 +174,7 @@ class WPBDP__Listing_Subscription {
             'subscription_id' => $this->subscription_id,
             'subscription_data' => serialize( $data )
         );
-
+		WPBDP_Utils::cache_delete_group( 'wpbdp_listings' );
         return $wpdb->update( $wpdb->prefix . 'wpbdp_listings', $row, array( 'listing_id' => $this->listing_id ) );
     }
 }

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -342,8 +342,17 @@ class WPBDP_Listing {
      * @since 5.0
      */
     public function has_subscription() {
-        global $wpdb;
-        return absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}wpbdp_listings WHERE listing_id = %d AND is_recurring = %d", $this->id, 1 ) ) ) > 0;
+		global $wpdb;
+		$query = $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}wpbdp_listings WHERE listing_id = %d AND is_recurring = %d", $this->id, 1 );
+		$total = WPBDP_Utils::check_cache(
+			array(
+				'cache_key' => 'listing_subscription_' . $this->id,
+				'group'     => 'wpbdp_listings',
+				'query'     => $query,
+				'type'      => 'get_var',
+			)
+		);
+		return absint( $total ) > 0;
     }
 
     public function is_published() {

--- a/templates/admin/metaboxes-listing-information-plan.tpl.php
+++ b/templates/admin/metaboxes-listing-information-plan.tpl.php
@@ -81,14 +81,17 @@ echo wp_nonce_field( 'update listing plan', 'wpbdp-admin-listing-plan-nonce', fa
             <span class="display-value" id="wpbdp-listing-plan-prop-expiration">
                 <?php echo ( $current_plan && $current_plan->expiration_date ) ? wpbdp_date_full_format( strtotime( $current_plan->expiration_date ) ) : ( $listing->get_fee_plan() ? 'Never' : '-' ); ?>
             </span>
-			<a href="#" class="edit-value-toggle"><?php esc_html_e( 'Edit', 'business-directory-plugin' ); ?></a>
+			<?php if ( ! $listing->has_subscription() ) : ?>
+				<a href="#" class="edit-value-toggle"><?php esc_html_e( 'Edit', 'business-directory-plugin' ); ?></a>
+			<?php endif; ?>
             <div class="value-editor">
 				<input type="text" name="listing_plan[expiration_date]" value="<?php echo esc_attr( ( $current_plan && $current_plan->expiration_date ) ? $current_plan->expiration_date : '' ); ?>" placeholder="<?php esc_attr_e( 'Never', 'business-directory-plugin' ); ?>" />
-
+				<?php if ( ! $listing->has_subscription() ) : ?>
                 <p>
                     <a href="#" class="update-value button"><?php _ex( 'OK', 'listing metabox', 'business-directory-plugin' ); ?></a>
                     <a href="#" class="cancel-edit button-cancel"><?php _ex( 'Cancel', 'listing metabox', 'business-directory-plugin' ); ?></a>
                 </p>
+				<?php endif; ?>
             </div>
         </dd>
         <dt><?php _ex( '# of images', 'listing metabox', 'business-directory-plugin' ); ?></dt>


### PR DESCRIPTION
Related issue : https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5053

This disabled the ability to edit the "Expire date" in a listing with an active subscription. Changing the expiration date can bring about many un-supported unrelated issues which we do not support now that include:

- An admin will assume editing the date to a future date for a listing of any status will give/take access to the end user and later on continue with the subscription process at this point
- Editing the date will be assumed to change the gateways that support subscription updates dates

![image](https://user-images.githubusercontent.com/121492/157293695-2bd4b140-4ced-4980-94b5-6dd99867d086.png)

Are there any other checks we should add? Subscription status are updated by the gateway