### PR TITLE
Add thumbnail settings

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -1065,10 +1065,10 @@ final class WPBDP__Settings__Bootstrap {
 				'name'    => __( 'Show Listing Thumbnail From', 'business-directory-plugin' ),
 				'default' => 'auto',
 				'options' => array(
-                    'auto'  => __( 'Business Directory Plugin', 'business-directory-plugin' ),
-                    'theme' => __( 'WordPress Theme', 'business-directory-plugin' ),
+					'auto'  => __( 'Business Directory Plugin', 'business-directory-plugin' ),
+					'theme' => __( 'WordPress Theme', 'business-directory-plugin' ),
 					'none'  => __( 'None', 'business-directory-plugin' ),
-                ),
+				),
 				'group'   => 'image/listings',
 			)
 		);

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -1060,6 +1060,21 @@ final class WPBDP__Settings__Bootstrap {
 
 		wpbdp_register_setting(
 			array(
+				'id'      => 'which-thumbnail',
+				'type'    => 'radio',
+				'name'    => __( 'Show Listing Thumbnail From', 'business-directory-plugin' ),
+				'default' => 'auto',
+				'options' => array(
+                    'auto'  => __( 'Business Directory Plugin', 'business-directory-plugin' ),
+                    'theme' => __( 'WordPress Theme', 'business-directory-plugin' ),
+					'none'  => __( 'None', 'business-directory-plugin' ),
+                ),
+				'group'   => 'image/listings',
+			)
+		);
+
+		wpbdp_register_setting(
+			array(
 				'id'      => 'listing-main-image-default-size',
 				'type'    => 'select',
 				'name'    => _x( 'Default thumbnail image size', 'settings', 'business-directory-plugin' ),

--- a/includes/class-cpt-integration.php
+++ b/includes/class-cpt-integration.php
@@ -50,6 +50,7 @@ class WPBDP__CPT_Integration {
             'hierarchical' => true,
             'public'       => true,
             'rewrite'      => array( 'slug' => wpbdp_get_option( 'permalinks-category-slug', WPBDP_CATEGORY_TAX ) ),
+			'show_in_rest' => true,
         );
         register_taxonomy( WPBDP_CATEGORY_TAX, WPBDP_POST_TYPE, $cat_args );
 
@@ -62,6 +63,7 @@ class WPBDP__CPT_Integration {
             'hierarchical' => false,
             'public'       => true,
             'rewrite'      => array( 'slug' => wpbdp_get_option( 'permalinks-tags-slug', WPBDP_TAGS_TAX ) ),
+			'show_in_rest' => true,
         );
 
         $tags_slug = wpbdp_get_option( 'permalinks-tags-slug', WPBDP_TAGS_TAX );

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -154,7 +154,7 @@ class WPBDP__WordPress_Template_Integration {
 	private function remove_theme_thumbnail() {
 		add_action( 'loop_start', array( &$this, 'set_thumbnail_visibility' ) );
 
-		// Support for themes that render the post-featured-image before $startup_hook.
+		// Support for themes that render the post-featured-image before loop_start.
 		add_filter( 'render_block_core/post-featured-image', array( &$this, 'remove_featured_image_block_thumb' ) );
 
 		// Support for the twentynineteen theme.

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -6,6 +6,11 @@ class WPBDP__WordPress_Template_Integration {
 
     private $displayed = false;
 
+	/**
+	 * @var int $post_id
+	 */
+	private $post_id = 0;
+
     public function __construct() {
         add_action( 'body_class', array( $this, 'add_basic_body_classes' ) );
         add_filter( 'body_class', array( &$this, 'add_advanced_body_classes' ), 10 );
@@ -20,6 +25,7 @@ class WPBDP__WordPress_Template_Integration {
 
         add_filter( 'template_include', array( $this, 'template_include' ), 20 );
         add_filter( 'post_class', array( $this, 'post_class' ), 10, 3 );
+		$this->remove_theme_thumbnail();
     }
 
     public function template_include( $template ) {
@@ -103,7 +109,6 @@ class WPBDP__WordPress_Template_Integration {
     }
 
     public function add_advanced_body_classes( $classes = array() ) {
-        global $wp_query;
         global $wpbdp;
 
         // FIXME: we need a better way to handle this, since it might be that a shortcode is being used and not something
@@ -142,6 +147,106 @@ class WPBDP__WordPress_Template_Integration {
 
         return $classes;
     }
+
+	/**
+	 * @since x.x
+	 */
+	private function remove_theme_thumbnail() {
+		add_action( 'loop_start', array( &$this, 'set_thumbnail_visibility' ) );
+
+		// Support for themes that render the post-featured-image before $startup_hook.
+		add_filter( 'render_block_core/post-featured-image', array( &$this, 'remove_featured_image_block_thumb' ) );
+
+		// Support for the twentynineteen theme.
+		add_filter( 'twentynineteen_can_show_post_thumbnail', array( &$this, 'remove_twentynineteen_thumb' ) );
+	}
+
+	/**
+	 * Hide the featured image on single posts where the corresponding flag
+	 * was set in the backend.
+	 *
+	 * @since x.x
+	 */
+	public function set_thumbnail_visibility() {
+		/**
+		 * Remove the filters, if it's not the main query. This is the case,
+		 * if the current query is executed after the main query.
+		 */
+		if ( is_embed() || ! $this->should_remove_theme_thumbnail() ) {
+			remove_filter( 'get_post_metadata', array( &$this, 'hide_featured_image_in_the_loop' ) );
+			$this->post_id = 0;
+			return;
+		}
+
+		// Hide the featured image.
+		$this->post_id = get_the_ID();
+		add_filter( 'get_post_metadata', array( &$this, 'hide_featured_image_in_the_loop' ), 10, 3 );
+	}
+
+	/**
+	 * Set the thumbnail_id to false if in the loop, to make the WordPress
+	 * core believe there is no thumbnail/featured image.
+	 *
+	 * @param mixed $value given by the get_post_metadata filter
+	 * @param int $object_id
+	 * @param string $meta_key
+	 *
+	 * @return mixed
+	 * @see has_post_thumbnail()
+	 * @since x.x
+	 */
+	public function hide_featured_image_in_the_loop( $value, $object_id, $meta_key ) {
+		if ( '_thumbnail_id' === $meta_key && $object_id === $this->post_id && in_the_loop() ) {
+			return false;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Prevent block rendering needed.
+	 *
+	 * If the featured image is marked hidden, we are in the main query and
+	 * the page is singular, the given block content is removed.
+	 *
+	 * @param string $block_content
+	 * @return string
+	 * @since x.x
+	 */
+	public function remove_featured_image_block_thumb( $block_content ) {
+		if ( $this->should_remove_theme_thumbnail() ) {
+			return '';
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Support for the twentynineteen theme.
+	 *
+	 * @param bool $show_thumbnail
+	 * @return bool
+	 * @since x.x
+	 */
+	public function remove_twentynineteen_thumb( $show_thumbnail ) {
+		if ( $show_thumbnail && $this->should_remove_theme_thumbnail() ) {
+			return false;
+		}
+
+		return $show_thumbnail;
+	}
+
+	/**
+	 * @return bool
+	 * @since x.x
+	 */
+	private function should_remove_theme_thumbnail() {
+		if ( ! is_main_query() || ! is_singular( WPBDP_POST_TYPE ) ) {
+			return false;
+		}
+		$which_thumbnail = wpbdp_get_option( 'which-thumbnail' );
+		return $which_thumbnail !== 'theme';
+	}
 
     private function end_query() {
         global $wp_query;

--- a/includes/helpers/class-listing-display-helper.php
+++ b/includes/helpers/class-listing-display-helper.php
@@ -256,8 +256,14 @@ class WPBDP_Listing_Display_Helper {
 			$pass_args['coming_soon'] = self::get_coming_soon_image();
 		}
 
+		$which_thumbnail   = wpbdp_get_option( 'which-thumbnail' );
+		$excerpt_thumbnail = wpbdp_get_option( 'show-thumbnail' );
+		$show_bd_thumb     = $which_thumbnail === 'auto' && $display === 'listing';
+
         // Thumbnail.
-        if ( wpbdp_get_option( 'show-thumbnail' ) ) {
+		if ( $display === 'listing' && ! $show_bd_thumb ) {
+			$vars['images']->thumbnail = false;
+		} elseif ( $excerpt_thumbnail ) {
 			$pass_args['link']  = 'listing';
 			$pass_args['class'] = 'wpbdmthumbs wpbdp-excerpt-thumbnail';
 
@@ -268,9 +274,9 @@ class WPBDP_Listing_Display_Helper {
         }
 
         // Main image.
-        $data_main    = wp_get_attachment_image_src( $thumbnail_id, 'wpbdp-large', false );
+		$data_main = wp_get_attachment_image_src( $thumbnail_id, 'wpbdp-large', false );
 
-        if ( $thumbnail_id ) {
+        if ( $thumbnail_id && $show_bd_thumb ) {
 			$pass_args['link']  = 'picture';
 			$pass_args['class'] = 'wpbdp-single-thumbnail';
 

--- a/includes/helpers/class-listing-display-helper.php
+++ b/includes/helpers/class-listing-display-helper.php
@@ -276,7 +276,7 @@ class WPBDP_Listing_Display_Helper {
         // Main image.
 		$data_main = wp_get_attachment_image_src( $thumbnail_id, 'wpbdp-large', false );
 
-        if ( $thumbnail_id && $show_bd_thumb ) {
+		if ( $thumbnail_id && $show_bd_thumb ) {
 			$pass_args['link']  = 'picture';
 			$pass_args['class'] = 'wpbdp-single-thumbnail';
 

--- a/templates/excerpt_content.tpl.php
+++ b/templates/excerpt_content.tpl.php
@@ -2,7 +2,7 @@
     <?php echo $images->thumbnail->html; ?>
 <?php endif; ?>
 
-<div class="listing-details">
+<div class="listing-details<?php echo esc_attr( $images->thumbnail ? '' : ' wpbdp-no-thumb' ); ?>">
     <?php foreach ( $fields->not( 'social' ) as $field ) : ?>
         <?php
 		$address = array( 'address', 'address2', 'city', 'state', 'country', 'zip' );

--- a/templates/single_content.tpl.php
+++ b/templates/single_content.tpl.php
@@ -16,7 +16,7 @@
 	</div>
 <?php endif; ?>
 
-<div class="listing-details cf">
+<div class="listing-details cf<?php echo esc_attr( ( $images->main || $images->thumbnail ) ? '' : ' wpbdp-no-thumb' ); ?>">
     <?php
 	foreach ( $fields->not( 'social' ) as $field ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/themes/default/assets/styles.css
+++ b/themes/default/assets/styles.css
@@ -33,6 +33,10 @@
 	margin-left: 160px;
 }
 
+.wpbdp-listing .listing-details.wpbdp-no-thumb {
+	margin-left: 0;
+}
+
 .wpbdp-listing .address-info .address-label {
 	font-weight: bold;
 	display: block;

--- a/themes/default/templates/single_content.tpl.php
+++ b/themes/default/templates/single_content.tpl.php
@@ -10,7 +10,7 @@
     <?php echo $images->main ? $images->main->html : $images->thumbnail->html; ?>
 <?php endif; ?>
 
-<div class="listing-details cf">
+<div class="listing-details cf<?php echo esc_attr( ( $images->main || $images->thumbnail ) ? '' : ' wpbdp-no-thumb' ); ?>">
     <?php foreach ( $fields->not( 'social' ) as $field ) : ?>
         <?php echo $field->html; ?>
     <?php endforeach; ?>


### PR DESCRIPTION
This adds a new setting under Appearance -> Images:
<img width="235" alt="Screen Shot 2022-05-13 at 1 23 35 PM" src="https://user-images.githubusercontent.com/1116876/168375703-fb5fa5d3-7ff0-4f37-8a40-0834ddeb33b6.png">

This setting will hide the thumbnail for most themes. There may still be themes this won't cover. By default, it will try and hide the theme thumbnail.