### PR TITLE
Add new hooks to change image sizes for images from fields

### DIFF
--- a/includes/fields/class-fieldtypes-image.php
+++ b/includes/fields/class-fieldtypes-image.php
@@ -201,17 +201,45 @@ class WPBDP_FieldTypes_Image extends WPBDP_Form_Field_Type {
 
         $thumbnail_width = absint( wpbdp_get_option( 'thumbnail-width' ) );
 
+		/**
+		 * Set a different image size for uploaded files.
+		 *
+		 * @since x.x
+		 */
+		$thumbnail_width = apply_filters(
+			'wpbdp_img_width',
+			$thumbnail_width,
+			array(
+				'listing_id' => $post_id,
+				'img_id'     => $field_value[0],
+			)
+		);
+
         $img = wp_get_attachment_image_src( $img_id, 'large' );
 
         if ( ! $img ) {
             return '';
         }
 
+		/**
+		 * Set a different image size for uploaded files.
+		 *
+		 * @since x.x
+		 */
+		$img_size = apply_filters(
+			'wpbd_img_size',
+			'wpbdp-thumb',
+			array(
+				'listing_id' => $post_id,
+				'img_id'     => $field_value[0],
+			)
+		);
+
         $html  = '';
         $html .= '<br />';
         $html .= '<div class="listing-image" style="width: ' . $thumbnail_width . 'px;">';
         $html .= '<a href="' . esc_url( $img[0] ) . '" target="_blank" rel="noopener" ' . ( wpbdp_get_option( 'use-thickbox' ) ? 'class="thickbox" data-lightbox="wpbdpgal" rel="wpbdpgal"' : '' ) . '>';
-        $html .= wp_get_attachment_image( $img_id, 'wpbdp-thumb', false, array( 'alt' => $caption ? $caption : esc_attr( $field->get_label() ) ) );
+        $html .= wp_get_attachment_image( $img_id, $img_size, false, array( 'alt' => $caption ? $caption : esc_attr( $field->get_label() ) ) );
         $html .= '</a>';
         $html .= $field->data( 'display_caption' ) ? '<br />' . $caption : '';
         $html .= '</div>';

--- a/includes/fields/class-fieldtypes-image.php
+++ b/includes/fields/class-fieldtypes-image.php
@@ -227,7 +227,7 @@ class WPBDP_FieldTypes_Image extends WPBDP_Form_Field_Type {
 		 * @since x.x
 		 */
 		$img_size = apply_filters(
-			'wpbd_img_size',
+			'wpbdp_img_size',
 			'wpbdp-thumb',
 			array(
 				'listing_id' => $post_id,


### PR DESCRIPTION
wpbdp_img_width and wpbdp_img_size

Examples:
```
function set_custom_image_width( $width, $atts ) {
  return 400; // Set the desired image width here.
}
add_filter( 'wpbdp_img_width', 'set_custom_image_width', 10, 2 );

function set_custom_image_size( $width, $atts ) {
  return 'full'; // Default is 'wpbdp-thumb'. Can also use medium, large.
}
add_filter( 'wpbdp_img_size', 'set_custom_image_size', 10, 2 );
```

$atts includes 'listing_id' and 'img_id'