### PR TITLE
Fix the text_template field type in settings

### DIFF
--- a/assets/css/less/admin-settings.less
+++ b/assets/css/less/admin-settings.less
@@ -196,27 +196,6 @@
             }
         }
 
-        .placeholders {
-            margin: 10px 0 0 0;
-        }
-
-        .placeholder {
-            font-size: 90%;
-
-            .placeholder-code {
-                font-family: monospace;
-                font-weight: bold;
-            }
-
-            .placeholder-description {
-                font-style: italic;
-            }
-        }
-
-        .placeholder-separator {
-            margin-top: 10px;
-        }
-
         .buttons {
             margin: 30px 0 0 0;
             text-align: right;
@@ -230,6 +209,29 @@
             }
         }
     }
+}
+
+#wpbdp-admin-page-settings {
+	.placeholders {
+		margin: 10px 0 0 0;
+	}
+
+	.placeholder {
+		font-size: 90%;
+
+		.placeholder-code {
+			font-family: monospace;
+			font-weight: bold;
+		}
+
+		.placeholder-description {
+			font-style: italic;
+		}
+	}
+
+	.placeholder-separator {
+		margin-top: 10px;
+	}
 }
 
 #wpbdp-admin-page-settings .wpbdp-settings-expiration-notices {

--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -189,10 +189,6 @@ class WPBDP__Settings_Admin {
 
             if ( method_exists( $this, 'setting_' . $setting['type'] . '_callback' ) ) {
                 call_user_func( array( $this, 'setting_' . $setting['type'] . '_callback' ), $setting, $value );
-				if ( method_exists( $this, 'change_setting_' . $setting['type'] . '_callback' ) ) {
-					// Change any settings here if needed.
-					$setting = call_user_func( array( $this, 'change_setting_' . $setting['type'] . '_callback' ), $setting );
-				}
             } else {
                 $this->setting_missing_callback( $setting, $value );
             }
@@ -576,40 +572,11 @@ class WPBDP__Settings_Admin {
     }
 
     public function setting_text_template_callback( $setting, $value ) {
-		$setting['type']         = 'text';
-		$setting['placeholders'] = array();
+		_deprecated_function( __METHOD__, '6.2.5' );
+		$setting['type'] = 'text';
 
         $this->setting_text_callback( $setting, $value );
     }
-
-	/**
-	 * Add all the placeholder options to the field description.
-	 *
-	 * @since x.x
-	 */
-	private function change_setting_text_template_callback( $setting ) {
-		$placeholders = isset( $setting['placeholders'] ) ? $setting['placeholders'] : array();
-
-        if ( ! $placeholders ) {
-			return $setting;
-		}
-
-		$placeholders_text = '';
-		foreach ( $placeholders as $pholder => $desc ) {
-			$placeholders_text .= '<br/><span class="placeholder" data-placeholder="' . esc_attr( $pholder ) . '">';
-			$placeholders_text .= '<span class="placeholder-code">[' . esc_html( $pholder ) . ']</span> - ';
-			$placeholders_text .= '<span class="placeholder-description">' . esc_html( $desc ) . '</span>';
-			$placeholders_text .= '</span>';
-		}
-
-		if ( $setting['desc'] ) {
-			$setting['desc'] .= '<br/>' . __( 'Valid placeholders:', 'business-directory-plugin' ) . $placeholders_text;
-		} else {
-			$setting['desc'] = $placeholders_text;
-		}
-
-		return $setting;
-	}
 
     public function setting_email_template_callback( $setting, $value ) {
         if ( ! is_array( $value ) ) {

--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -367,8 +367,27 @@ class WPBDP__Settings_Admin {
 
 		echo wp_kses_post( $setting['desc'] );
 
+		self::add_placeholders( $setting );
+
 		if ( $include_wrap ) {
 			echo '</' . esc_attr( $include_wrap ) . '>';
+		}
+	}
+
+	/**
+	 * @since x.x
+	 */
+	private function add_placeholders( $setting ) {
+		if ( empty( $setting['placeholders'] ) ) {
+			return;
+		}
+
+		echo '<br/>' . __( 'Valid placeholders:', 'business-directory-plugin' );
+		foreach ( $setting['placeholders'] as $pholder => $desc ) {
+			echo '<br/><span class="placeholder" data-placeholder="' . esc_attr( $pholder ) . '">';
+			echo '<span class="placeholder-code">[' . esc_html( $pholder ) . ']</span> - ';
+			echo '<span class="placeholder-description">' . esc_html( $desc ) . '</span>';
+			echo '</span>';
 		}
 	}
 


### PR DESCRIPTION
There was a text_template type that was only being used in one place, so we'll just scrap it. The only thing this field type did was handle the 'placeholders' if included.

This PR allows the 'placeholders' on any field type.