### PR TITLE
Fix the fatal error on the manual upgrade page

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -229,6 +229,9 @@ class WPBDP_Admin_Pages {
 		 * @since 6.0.1
 		 */
 		$tabs = apply_filters( 'wpbdp_tab_content', $tabs, array( 'settings' => ! empty( $args['tabs'] ) ) );
+		if ( empty( $tabs ) ) {
+			return;
+		}
 		self::add_icon_url( $tabs );
 
 		$title = $args['title'];


### PR DESCRIPTION
This fixes the error mentioned here:
https://wordpress.org/support/topic/critical-error-after-updating-3/

This can be seen by installing a 4.x version and then update to current.