### PR TITLE
If thumbnail isn't showing on listing, include it in the gallery

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -910,10 +910,11 @@ final class WPBDP__Settings__Bootstrap {
                 'type'    => 'number',
                 'min'     => 0,
                 'step'    => 1,
-                'name'    => _x( 'Min Image File Size (KB)', 'settings', 'business-directory-plugin' ),
+				'name'    => __( 'Min image file size (KB)', 'business-directory-plugin' ),
                 'default' => '0',
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -922,10 +923,11 @@ final class WPBDP__Settings__Bootstrap {
                 'type'    => 'number',
                 'min'     => 0,
                 'step'    => 1,
-                'name'    => _x( 'Max Image File Size (KB)', 'settings', 'business-directory-plugin' ),
+				'name'    => __( 'Max image file size (KB)', 'business-directory-plugin' ),
                 'default' => '10000',
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -938,6 +940,7 @@ final class WPBDP__Settings__Bootstrap {
                 'default' => '0',
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -950,6 +953,7 @@ final class WPBDP__Settings__Bootstrap {
                 'step'    => 1,
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -962,6 +966,7 @@ final class WPBDP__Settings__Bootstrap {
                 'default' => '500',
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -974,6 +979,7 @@ final class WPBDP__Settings__Bootstrap {
                 'default' => '500',
                 'group'   => 'images/general',
 				'class'   => 'wpbdp-half',
+				'requirements' => array( 'allow-images' ),
             )
         );
         wpbdp_register_setting(
@@ -1039,9 +1045,8 @@ final class WPBDP__Settings__Bootstrap {
 		wpbdp_register_setting(
 			array(
 				'id'      => 'show-thumbnail',
-				'type'    => 'checkbox',
-				'name'    => __( 'Show Thumbnail', 'business-directory-plugin' ),
-				'desc'    => _x( 'Excerpt view.', 'admin settings', 'business-directory-plugin' ),
+				'type'    => 'toggle',
+				'name'    => __( 'Show thumbnail in excerpt', 'business-directory-plugin' ),
 				'default' => true,
 				'group'   => 'image/thumbnails',
 			)
@@ -1051,7 +1056,7 @@ final class WPBDP__Settings__Bootstrap {
 			array(
 				'id'      => 'which-thumbnail',
 				'type'    => 'radio',
-				'name'    => __( 'Show Listing Thumbnail From', 'business-directory-plugin' ),
+				'name'    => __( 'Show thumbnail in listing from:', 'business-directory-plugin' ),
 				'default' => 'auto',
 				'options' => array(
 					'auto'  => __( 'Business Directory Plugin', 'business-directory-plugin' ),

--- a/includes/helpers/class-listing-display-helper.php
+++ b/includes/helpers/class-listing-display-helper.php
@@ -302,7 +302,7 @@ class WPBDP_Listing_Display_Helper {
 
             if ( $img_id == $thumbnail_id ) {
 				$skipped_thumb = $which_thumbnail === 'none' && $display === 'listing';
-				if ( ! $skipped_thumb ) {
+				if ( ! $skipped_thumb && count( $listing_images ) > 1 ) {
 					// If the thumbnail won't be shown, include it in the gallery.
 					continue;
 				}

--- a/includes/helpers/class-listing-display-helper.php
+++ b/includes/helpers/class-listing-display-helper.php
@@ -301,7 +301,11 @@ class WPBDP_Listing_Display_Helper {
         foreach ( $listing_images as $img_id ) {
 
             if ( $img_id == $thumbnail_id ) {
-                continue;
+				$skipped_thumb = $which_thumbnail === 'none' && $display === 'listing';
+				if ( ! $skipped_thumb ) {
+					// If the thumbnail won't be shown, include it in the gallery.
+					continue;
+				}
             }
 
             $data    = wp_get_attachment_image_src( $img_id, 'wpbdp-large', false );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5104
If the listing only had a thumbnail before, don't add it to the gallery for reverse compatibility.

Also: 
- hide the image size settings when "allow images" is off.
- Switch "Show Thumbnail" checkbox to "Show thumbnail in excerpt" toggle
- Change "Show Listing Thumbnail From" to "Show thumbnail in listing from:"