### PR TITLE
Fix category header for block themes

### DIFF
--- a/includes/controllers/pages/class-show-category.php
+++ b/includes/controllers/pages/class-show-category.php
@@ -15,6 +15,10 @@ class WPBDP__Views__Show_Category extends WPBDP__View {
         $html = '';
 
         if ( is_object( $term ) ) {
+			if ( WPBDP__Themes_Compat::is_block_theme() ) {
+				global $wpbdp;
+				$wpbdp->template_integration->prep_tax_head();
+			}
 			$html = $this->get_taxonomy_html( $term );
         }
 


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5094
This prevents the title and image showing at the top of the category page in some themes like Astra and 2022