### PR TITLE
Prevent repeat content on category pages

### DIFF
--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -15,7 +15,7 @@ class WPBDP__Query_Integration {
         add_action( 'parse_query', array( $this, 'set_query_flags' ), 50 );
         add_action( 'template_redirect', array( $this, 'set_404_flag' ), 0 );
 
-        add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ), 10, 1 );
+        add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ), 10 );
         add_filter( 'posts_clauses', array( $this, 'posts_clauses' ), 10, 2 );
 
         // Core sorting options.
@@ -62,6 +62,7 @@ class WPBDP__Query_Integration {
         $query->wpbdp_is_tag       = false;
         $query->wpbdp_our_query    = false;
         $query->wpbdp_is_shortcode = false;
+        $query->wpbdp_in_the_loop  = false;
 
         // Is this a listing query?
         // FIXME: this results in false positives frequently.
@@ -78,7 +79,6 @@ class WPBDP__Query_Integration {
             $query->wpbdp_view        = 'show_category';
         }
 
-        // wpbdp_debug_e( $query );
         $tags_slug = wpbdp_get_option( 'permalinks-tags-slug' );
         if ( ! empty( $query->query_vars[ WPBDP_TAGS_TAX ] ) ) {
             $query->wpbdp_is_tag = true;
@@ -178,7 +178,8 @@ class WPBDP__Query_Integration {
         }
 
         if ( $query->wpbdp_is_category || $query->wpbdp_is_tag ) {
-            $current_post_types = $query->get( 'post_type' ) ? $query->get( 'post_type' ) : array();
+            $post_type = $query->get( 'post_type' );
+            $current_post_types = $post_type ? $post_type : array();
 
             if ( ! is_array( $current_post_types ) ) {
                 $current_post_types = array( $current_post_types );

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -81,10 +81,8 @@ class WPBDP__WordPress_Template_Integration {
 			$this->prep_tax_head();
 		}
 
-        remove_filter( 'the_content', 'wpautop' );
-
 		// Run last so other hooks don't break our output.
-        add_filter( 'the_content', array( $this, 'display_view_in_content' ), 5 );
+        add_filter( 'the_content', array( $this, 'display_view_in_content' ), 999 );
         remove_action( 'loop_start', array( $this, 'setup_post_hooks' ) );
     }
 
@@ -147,6 +145,10 @@ class WPBDP__WordPress_Template_Integration {
         }
 
         $html = wpbdp_current_view_output();
+
+		if ( is_tax() ) {
+            $this->end_query();
+		}
 
         $this->displayed = true;
 
@@ -300,6 +302,13 @@ class WPBDP__WordPress_Template_Integration {
 		$which_thumbnail = wpbdp_get_option( 'which-thumbnail' );
 		return $which_thumbnail !== 'theme';
 	}
+
+	private function end_query() {
+        global $wp_query;
+
+        $wp_query->current_post = -1;
+        $wp_query->post_count   = 0;
+    }
 
 	public function _comments_template( $template ) {
         $is_single_listing = is_single() && get_post_type() == WPBDP_POST_TYPE;

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -127,11 +127,11 @@ class WPBDP__WordPress_Template_Integration {
 	 * @return string
 	 */
 	public function remove_tax_thumbnail( $thumbnail ) {
+		remove_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
+
 		if ( $this->in_the_loop() ) {
 			return $thumbnail;
 		}
-
-		remove_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
 
 		// The caption shows in 2021 theme.
 		add_filter( 'wp_get_attachment_caption', '__return_false' );
@@ -148,7 +148,7 @@ class WPBDP__WordPress_Template_Integration {
         $html = wpbdp_current_view_output();
 
 		if ( is_tax() ) {
-            $this->end_query();
+			$this->end_query();
 		}
 
         $this->displayed = true;
@@ -317,11 +317,11 @@ class WPBDP__WordPress_Template_Integration {
 	}
 
 	private function end_query() {
-        global $wp_query;
+		global $wp_query;
 
-        $wp_query->current_post = -1;
-        $wp_query->post_count   = 0;
-    }
+		$wp_query->current_post = -1;
+		$wp_query->post_count   = 0;
+	}
 
 	public function _comments_template( $template ) {
         $is_single_listing = is_single() && get_post_type() == WPBDP_POST_TYPE;

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -87,7 +87,7 @@ class WPBDP__WordPress_Template_Integration {
 		}
 
 		// Run last so other hooks don't break our output.
-        add_filter( 'the_content', array( $this, 'display_view_in_content' ), 999 );
+		add_filter( 'the_content', array( $this, 'display_view_in_content' ), 999 );
         remove_action( 'loop_start', array( $this, 'setup_post_hooks' ) );
     }
 
@@ -139,6 +139,18 @@ class WPBDP__WordPress_Template_Integration {
 		return '';
 	}
 
+	/**
+	 * Some themes run the taxonomy title in the loop too.
+	 * Check our custom loop flag.
+	 *
+	 * @since x.x
+	 * @return bool
+	 */
+	private function in_the_loop() {
+		global $wp_query;
+		return $wp_query->wpbdp_in_the_loop;
+	}
+
     public function display_view_in_content( $content = '' ) {
 		remove_filter( 'the_content', array( $this, 'display_view_in_content' ), 5 );
         if ( $this->displayed ) {
@@ -155,18 +167,6 @@ class WPBDP__WordPress_Template_Integration {
 
         return $html;
     }
-
-	/**
-	 * Some themes run the taxonomy title in the loop too.
-	 * Check our custom loop flag.
-	 *
-	 * @since x.x
-	 * @return bool
-	 */
-	private function in_the_loop() {
-		global $wp_query;
-		return $wp_query->wpbdp_in_the_loop;
-	}
 
     public function add_basic_body_classes( $classes = array() ) {
 		if ( 'theme' === wpbdp_get_option( 'themes-button-style' ) ) {

--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -43,6 +43,11 @@ class WPBDP__WordPress_Template_Integration {
 
 		$allow_override = apply_filters( 'wpbdp_allow_template_override', true );
 
+		if ( $wp_query->is_tax() ) {
+			// Force some themes to use the page template.
+			$wp_query->is_singular = true;
+		}
+
 		if ( $allow_override ) {
 			add_action( 'loop_start', array( $this, 'setup_post_hooks' ) );
 			$page_template = get_query_template( 'page', $this->get_template_alternatives() );
@@ -94,7 +99,6 @@ class WPBDP__WordPress_Template_Integration {
 	public function prep_tax_head() {
 		add_filter( 'the_title', array( &$this, 'set_tax_title' ) );
 		add_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
-		add_filter( 'astra_featured_image_markup', array( &$this, 'remove_tax_thumbnail' ) );
 	}
 
 	/**
@@ -106,7 +110,8 @@ class WPBDP__WordPress_Template_Integration {
 	 * @return string
 	 */
 	public function set_tax_title( $title ) {
-		if ( in_the_loop() && WPBDP__Themes_Compat::is_block_theme() ) {
+		if ( $this->in_the_loop() ) {
+			// If this is not a category, don't change it.
 			return $title;
 		}
 
@@ -122,15 +127,11 @@ class WPBDP__WordPress_Template_Integration {
 	 * @return string
 	 */
 	public function remove_tax_thumbnail( $thumbnail ) {
-		if ( WPBDP__Themes_Compat::is_block_theme() ) {
-			if ( in_the_loop() ) {
-				remove_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
-
-				return $thumbnail;
-			}
-		} else {
-			remove_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
+		if ( $this->in_the_loop() ) {
+			return $thumbnail;
 		}
+
+		remove_filter( 'post_thumbnail_html', array( &$this, 'remove_tax_thumbnail' ) );
 
 		// The caption shows in 2021 theme.
 		add_filter( 'wp_get_attachment_caption', '__return_false' );
@@ -154,6 +155,18 @@ class WPBDP__WordPress_Template_Integration {
 
         return $html;
     }
+
+	/**
+	 * Some themes run the taxonomy title in the loop too.
+	 * Check our custom loop flag.
+	 *
+	 * @since x.x
+	 * @return bool
+	 */
+	private function in_the_loop() {
+		global $wp_query;
+		return $wp_query->wpbdp_in_the_loop;
+	}
 
     public function add_basic_body_classes( $classes = array() ) {
 		if ( 'theme' === wpbdp_get_option( 'themes-button-style' ) ) {

--- a/includes/controllers/pages/class-show-category.php
+++ b/includes/controllers/pages/class-show-category.php
@@ -15,7 +15,7 @@ class WPBDP__Views__Show_Category extends WPBDP__View {
         $html = '';
 
         if ( is_object( $term ) ) {
-			if ( is_callable( 'WPBDP__Themes_Compat::s_block_theme' ) && WPBDP__Themes_Compat::is_block_theme() ) {
+			if ( is_callable( 'WPBDP__Themes_Compat::is_block_theme' ) && WPBDP__Themes_Compat::is_block_theme() ) {
 				// This isn't loaded when disable-cpt is on.
 				global $wpbdp;
 				$wpbdp->template_integration->prep_tax_head();

--- a/templates/parts/listings-loop.tpl.php
+++ b/templates/parts/listings-loop.tpl.php
@@ -9,6 +9,7 @@ if ( $query->have_posts() ) :
 		wpbdp_render_listing( null, 'excerpt', 'echo' );
 	}
 
+	/** @phpstan-ignore-next-line */
 	$wp_query->wpbdp_in_the_loop = false;
 
 	/** @phpstan-ignore-next-line */

--- a/templates/parts/listings-loop.tpl.php
+++ b/templates/parts/listings-loop.tpl.php
@@ -1,10 +1,15 @@
 <?php
 if ( $query->have_posts() ) :
+	global $wp_query;
+	$wp_query->wpbdp_in_the_loop = true;
+
 	/** @phpstan-ignore-next-line */
 	while ( $query->have_posts() ) {
 		$query->the_post();
 		wpbdp_render_listing( null, 'excerpt', 'echo' );
 	}
+
+	$wp_query->wpbdp_in_the_loop = false;
 
 	/** @phpstan-ignore-next-line */
 	wpbdp_x_part(


### PR DESCRIPTION
In Divi, the listings were displaying twice on category pages. https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5116

The problem is, this prevents listings from showing up in some other themes. This PR causes an issue with Customizr. I'd like to check other themes too.

With this PR, these themes work well for me on the all listings, category, and single listing pages:
- Astra
- Divi
- 2022

Let's find out if any other themes have trouble so we know what to target.