### PR TITLE
Process shortcodes in textarea when enabled

### DIFF
--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -152,7 +152,7 @@ class WPBDP__WordPress_Template_Integration {
 	}
 
     public function display_view_in_content( $content = '' ) {
-		remove_filter( 'the_content', array( $this, 'display_view_in_content' ), 5 );
+		remove_filter( 'the_content', array( $this, 'display_view_in_content' ), 999 );
         if ( $this->displayed ) {
             return '';
         }

--- a/includes/fields/class-fieldtypes-textarea.php
+++ b/includes/fields/class-fieldtypes-textarea.php
@@ -325,16 +325,7 @@ class WPBDP_FieldTypes_TextArea extends WPBDP_Form_Field_Type {
 
         if ( 'content' == $field->get_association() ) {
             if ( $field->data( 'allow_filters' ) ) {
-                // Prevent Jetpack sharing from appearing twice. (#2039)
-                $jetpack_hack = has_filter( 'the_content', 'sharing_display' );
-
-                if ( $jetpack_hack )
-                    remove_filter( 'the_content', 'sharing_display', 19 );
-
                 $value = apply_filters( 'the_content', $value );
-
-                if ( $jetpack_hack )
-                    add_filter( 'the_content', 'sharing_display', 19 );
             } else {
 				$value = wpautop( $value );
 				if ( $field->data( 'allow_shortcodes' ) ) {

--- a/includes/fields/class-fieldtypes-textarea.php
+++ b/includes/fields/class-fieldtypes-textarea.php
@@ -336,41 +336,22 @@ class WPBDP_FieldTypes_TextArea extends WPBDP_Form_Field_Type {
                 if ( $jetpack_hack )
                     add_filter( 'the_content', 'sharing_display', 19 );
             } else {
-                if ( $field->data( 'allow_shortcodes' ) ) {
-                    global $post;
-                    // Try to protect us from sortcodes messing things for us.
-                    $current_post = $post;
-
-                    $value = wpautop( $value );
-
-                    if ( wpbdp_get_option( 'disable-cpt' ) || in_array( wpbdp_current_view(), array( 'search', 'all_listings' ), true ) ) {
-                        $value = do_shortcode( shortcode_unautop( $value ) );
-                    }
-
-                    $post = $current_post;
-                } else {
-                    $value = wpautop( $value );
-                }
+				$value = wpautop( $value );
+				if ( $field->data( 'allow_shortcodes' ) ) {
+					$value = do_shortcode( shortcode_unautop( $value ) );
+				}
             }
         } elseif ( 'excerpt' == $field->get_association() ) {
             if ( $field->data( 'auto_excerpt' ) ) {
                 $value = $this->get_excerpt_value_from_post( $post_id );
             }
 
-            if ( $field->data( 'allow_shortcodes' ) ) {
-                global $post;
-                // Try to protect us from sortcodes messing things for us.
-                $current_post = $post;
-
-                $value = wpautop( $value );
-                $value = do_shortcode( shortcode_unautop( $value ) );
-
-                $post = $current_post;
-            } else {
-                if ( $field->data( 'allow_html' ) ) {
-                    $value = wpautop( $value );
-                }
-            }
+			if ( $field->data( 'allow_shortcodes' ) ) {
+				$value = wpautop( $value );
+				$value = do_shortcode( shortcode_unautop( $value ) );
+			} elseif ( $field->data( 'allow_html' ) ) {
+				$value = wpautop( $value );
+			}
 
             if ( ! $field->data( 'allow_html' ) ) {
                 $value = nl2br( $value );


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5119

Shortcodes were being processed all the time before 6.2.6, even when the setting was turned off. This correctly processes shortcodes only when they should be processed.