### PR TITLE
Hide Directory Listings Slug setting since it's not used

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -62,6 +62,7 @@ final class WPBDP__Settings__Bootstrap {
                 'group'     => 'permalink_settings',
                 'validator' => 'no-spaces,trim,required',
 				'class'     => 'wpbdp-half',
+				'requirements' => array( 'disable-cpt' ),
             )
         );
         wpbdp_register_setting(


### PR DESCRIPTION
This will only show when CPT is disabled.

Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/4863