### PR TITLE
Switch back to using the catgory template for most themes

### DIFF
--- a/includes/class-wordpress-template-integration.php
+++ b/includes/class-wordpress-template-integration.php
@@ -48,9 +48,12 @@ class WPBDP__WordPress_Template_Integration {
 		 *
 		 * @since 6.2.7
 		 */
-		if ( $wp_query->is_tax() && apply_filters( 'wpbdp_use_single', true ) ) {
+		if ( $wp_query->is_tax() && apply_filters( 'wpbdp_use_single', false ) ) {
 			// Force some themes to use the page template.
 			$wp_query->is_singular = true;
+
+			// Prevent a PHP error when WP gets confused.
+			add_filter( 'pre_get_shortlink', '__return_empty_string' );
 		}
 
 		if ( $allow_override ) {

--- a/includes/compatibility/class-compat.php
+++ b/includes/compatibility/class-compat.php
@@ -55,12 +55,39 @@ class WPBDP_Compat {
             require_once WPBDP_PATH . 'includes/compatibility/class-beaver-themer-compat.php';
 			new WPBDP_Beaver_Themer_Compat();
         }
+
+		// Yoast SEO.
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			add_action( 'wp_head', array( &$this, 'yoast_maybe_force_taxonomy' ), 0 );
+		}
     }
 
     public function cpt_compat_mode() {
         require_once WPBDP_PATH . 'includes/compatibility/class-cpt-compat-mode.php';
         $nocpt = new WPBDP__CPT_Compat_Mode();
     }
+
+	/**
+	 * If the category page is using a page template for the current theme,
+	 * remove the singular flag momentarily.
+	 *
+	 * @since x.x
+	 */
+	public function yoast_maybe_force_taxonomy() {
+		global $wp_query;
+		if ( wpbdp_is_taxonomy() && $wp_query->is_singular ) {
+			$wp_query->is_singular = false;
+			add_action( 'wpseo_head', array( &$this, 'yoast_force_page' ), 9999 );
+		}
+	}
+
+	/**
+	 * @since x.x
+	 */
+	public function yoast_force_page() {
+		global $wp_query;
+		$wp_query->is_singular = true;
+	}
 
     // Work around WP bugs. {{{
     public function workarounds_for_wp_bugs() {

--- a/includes/compatibility/class-compat.php
+++ b/includes/compatibility/class-compat.php
@@ -82,6 +82,8 @@ class WPBDP_Compat {
 	}
 
 	/**
+	 * Switch back to singular, since the current theme needs it.
+	 *
 	 * @since x.x
 	 */
 	public function yoast_force_page() {

--- a/includes/compatibility/class-themes-compat.php
+++ b/includes/compatibility/class-themes-compat.php
@@ -43,21 +43,22 @@ class WPBDP__Themes_Compat {
         }
     }
 
-    public function get_themes_with_fixes() {
-        $themes_with_fixes = array(
-            'astra',
-            'atahualpa', 'genesis', 'hmtpro5', 'customizr', 'customizr-pro',
-            'canvas', 'builder', 'divi',
+	public function get_themes_with_fixes() {
+		$themes_with_fixes = array(
+			'astra',
+			'atahualpa', 'genesis', 'hmtpro5',
+			'customizr', 'customizr-pro',
+			'canvas', 'builder', 'divi',
 			'hello-elementor',
 			'longevity', 'x', 'u-design', 'thesis',
-            'takeawaywp',
+			'takeawaywp',
 			'twentynineteen',
-            'foodiepro-2.1.8',
-            'ultimatum',
-        );
+			'foodiepro-2.1.8',
+			'ultimatum',
+		);
 
-        return apply_filters( 'wpbdp_themes_with_fixes_list', $themes_with_fixes );
-    }
+		return apply_filters( 'wpbdp_themes_with_fixes_list', $themes_with_fixes );
+	}
 
     //
     // {{ Fixes for some themes.

--- a/includes/compatibility/class-themes-compat.php
+++ b/includes/compatibility/class-themes-compat.php
@@ -45,8 +45,11 @@ class WPBDP__Themes_Compat {
 
     public function get_themes_with_fixes() {
         $themes_with_fixes = array(
+            'astra',
             'atahualpa', 'genesis', 'hmtpro5', 'customizr', 'customizr-pro',
-            'canvas', 'builder', 'divi', 'longevity', 'x', 'u-design', 'thesis',
+            'canvas', 'builder', 'divi',
+			'hello-elementor',
+			'longevity', 'x', 'u-design', 'thesis',
             'takeawaywp',
 			'twentynineteen',
             'foodiepro-2.1.8',
@@ -59,6 +62,20 @@ class WPBDP__Themes_Compat {
     //
     // {{ Fixes for some themes.
     //
+
+	/**
+	 * @since x.x
+	 */
+	public function theme_astra() {
+		if ( ! wpbdp_is_taxonomy() ) {
+			return;
+		}
+
+		$wpbdp = wpbdp();
+		if ( $wpbdp->template_integration ) {
+			add_filter( 'astra_featured_image_markup', array( $wpbdp->template_integration, 'remove_tax_thumbnail' ) );
+		}
+	}
 
     public function theme_genesis() {
         $is_listings_view = in_array( wpbdp_current_view(), array( 'all_listings', 'show_listing' ), true );
@@ -104,7 +121,7 @@ class WPBDP__Themes_Compat {
 
         $current_view = wpbdp_current_view();
 
-        if ( $current_view == 'show_listing' ) {
+		if ( $current_view === 'show_listing' ) {
             $this->theme_customizr_hide_post_thumb();
             $this->theme_customizr_disable_comments();
         }
@@ -113,6 +130,7 @@ class WPBDP__Themes_Compat {
             return;
         }
 
+		add_filter( 'wpbdp_use_single', '__return_true' );
         add_filter( 'tc_is_grid_enabled', '__return_false', 999 );
         add_filter( 'tc_show_excerpt', '__return_false', 999 );
         add_filter( 'tc_post_list_controller', '__return_true', 999 );
@@ -199,9 +217,6 @@ class WPBDP__Themes_Compat {
             return;
         }
 
-		// Divi don't need to load the single page template.
-		add_filter( 'wpbdp_use_single', '__return_false' );
-
         if ( 'et_full_width_page' != get_post_meta( wpbdp_get_page_id( 'main' ), '_et_pb_page_layout', true ) ) {
             return;
         }
@@ -218,6 +233,17 @@ class WPBDP__Themes_Compat {
     public function theme_divi_disable_sidebar( $is_active_sidebar, $index ) {
         return $index == 'sidebar-1' ? false : $is_active_sidebar;
     }
+
+	/**
+	 * @since x.x
+	 */
+	public function theme_hello_elementor() {
+		if ( ! wpbdp_is_taxonomy() ) {
+			return;
+		}
+
+		add_filter( 'wpbdp_use_single', '__return_true' );
+	}
 
     public function theme_longevity() {
         if ( ! wpbdp_is_taxonomy() ) {
@@ -303,9 +329,6 @@ class WPBDP__Themes_Compat {
 	public function theme_twentynineteen() {
 		// Set the thumbnail based on the settings.
 		add_filter( 'twentynineteen_can_show_post_thumbnail', array( &$this, 'remove_twentynineteen_thumb' ) );
-
-		// Fix the category page.
-		add_filter( 'wpbdp_use_single', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
* fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5133
* Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5131

This switches back to defaulting to the category template page. We override the themes with issues with the category page. This includes Customizr and Hello Elementor.