### PR TITLE
Show instruction message on first page only

### DIFF
--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -692,16 +692,16 @@ final class WPBDP__Settings__Bootstrap {
 			)
 		);
 
-        wpbdp_register_setting(
-            array(
-                'id'      => 'submit-instructions',
-                'type'    => 'textarea',
-                'name'    => _x( 'Submit Listing instructions message', 'settings', 'business-directory-plugin' ),
-                'desc'    => __( 'This text is displayed on the first page of the Submit Listing process. You can use it for instructions about filling out the form or information to get started.', 'business-directory-plugin' ),
-                'default' => '',
-                'group'   => 'listings/strings',
-            )
-        );
+		wpbdp_register_setting(
+			array(
+				'id'      => 'submit-instructions',
+				'type'    => 'textarea',
+				'name'    => __( 'Submit listing instructions', 'business-directory-plugin' ),
+				'tooltip' => __( 'This text is displayed on the first page of the Submit Listing process. You can use it for instructions about filling out the form or information to get started.', 'business-directory-plugin' ),
+				'default' => '',
+				'group'   => 'listings/strings',
+			)
+		);
 
         wpbdp_register_setting(
             array(

--- a/includes/controllers/pages/class-submit-listing.php
+++ b/includes/controllers/pages/class-submit-listing.php
@@ -253,9 +253,12 @@ class WPBDP__Views__Submit_Listing extends WPBDP__Authenticated_Listing_View {
 			$this->messages( _x( 'You\'re logged in as admin, payment will be skipped.', 'submit listing', 'business-directory-plugin' ), 'notice', 'general' );
 		}
 
-		$instructions = trim( wpbdp_get_option( 'submit-instructions' ) );
-		if ( $instructions ) {
-			$this->messages( $instructions, 'tip', 'general' );
+		if ( $this->current_section === reset( $this->sections_keys ) ) {
+			// Show message on the first page.
+			$instructions = trim( wpbdp_get_option( 'submit-instructions' ) );
+			if ( $instructions ) {
+				$this->messages( $instructions, 'tip', 'general' );
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/Strategy11/BusinessDirectoryPlugin/issues/5141

This also changes the setting label from "Submit Listing instructions message" to "Submit listing instructions"