### PR TITLE
Fix showing two admin menus for the editor role

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -515,9 +515,16 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			$cpt_menu   = 'edit.php?post_type=' . WPBDP_POST_TYPE;
 			$admin_menu = $this->menu_id;
 
-			if ( isset( $submenu[ $cpt_menu ] ) && isset( $submenu[ $admin_menu ] ) ) {
+			$current_user = wp_get_current_user();
+			$roles        = $current_user instanceof WP_User ? $current_user->roles : [];
+			$role         = ! empty( $roles ) && is_array( $roles ) ? array_shift( $roles ) : '';
+
+			if ( isset( $submenu[ $cpt_menu ] ) && ( isset( $submenu[ $admin_menu ] ) || $role === 'editor' ) ) {
 				$this->change_menu_name( $submenu[ $cpt_menu ] );
-				$submenu[ $admin_menu ] = array_merge( $submenu[ $cpt_menu ], $submenu[ $admin_menu ] );
+
+				$submenu[ $admin_menu ] = isset( $submenu[ $admin_menu ] ) ?
+					array_merge( $submenu[ $cpt_menu ], $submenu[ $admin_menu ] ) :
+					$submenu[ $cpt_menu ];
 			}
 		}
 


### PR DESCRIPTION
### Issue link:
https://github.com/Strategy11/business-directory-premium/issues/106

Changes proposed in this Pull Request:
With this Pull Request, we will fix showing two admin menus for the editor role.

#### Before PR: 
![image](https://user-images.githubusercontent.com/69119241/211870810-8aa38318-dec7-4923-b13a-32ee22fd30eb.png)

#### After PR:
![image](https://user-images.githubusercontent.com/69119241/211870842-37a1f567-a3fa-447a-a309-2e3a54cb099c.png)
