### PR TITLE
Fix: Expired listings on recurring fee plans cannot be renewed issue

### DIFF
--- a/includes/controllers/pages/class-renew-listing.php
+++ b/includes/controllers/pages/class-renew-listing.php
@@ -63,7 +63,7 @@ class WPBDP__Views__Renew_Listing extends WPBDP__Authenticated_Listing_View {
 			return $this->_redirect( $payment->get_checkout_url() );
 		}
 
-		if ( $this->plan->is_recurring && $this->listing->has_subscription() ) {
+		if ( $this->plan->is_recurring && $this->listing->has_subscription() && $status !== 'expired' ) {
 			return $this->render_manage_subscription_page( $this->listing, $this->plan );
 		}
 


### PR DESCRIPTION
### Issue Link:
https://github.com/Strategy11/business-directory-premium/issues/114

### Before this PR output:

<kbd>
<img src="https://user-images.githubusercontent.com/69119241/224451937-872477e7-c2c0-4f3d-9e47-28105b45c8e0.png" />
</kbd>

### After this PR output:

<kbd>
<img src="https://user-images.githubusercontent.com/69119241/224451949-ff80ae69-ff24-4a6d-8859-a670ba0e04db.png" />
</kbd>

### To reproduce:
- Put any expired listing on a recurring fee plan and save the changes
- Log in as the user with the expired listing
- Go to manage listings
- See the error shown above