### PR TITLE
Fix: FontAwesome doesn't work when optional text for URL is added

### DIFF
--- a/includes/fields/class-fieldtypes-url.php
+++ b/includes/fields/class-fieldtypes-url.php
@@ -85,7 +85,7 @@ class WPBDP_FieldTypes_URL extends WPBDP_Form_Field_Type {
 			$rel .= ' noopener';
 		}
 
-		$label = empty( $value[1] ) ? $value[0] : $value[1];
+		$label = empty( $value[1] ) || $field->data( 'icon' ) ? $value[0] : $value[1];
 
 		return sprintf(
 			'<a href="%s" rel="%s" target="%s" title="%s">%s</a>',


### PR DESCRIPTION
### Issue Link:
https://github.com/Strategy11/business-directory-premium/issues/115

### Reproduce:

- Install FontAwesome on a site with the Premium License
- Choose a table layout under the Appearance tab
- In the URL field, choose "replace the value with icon"
- In the listing, add a URL AND text in the optional text field
- The optional text overrides the icon setting as shown below:

### Before the PR:
![image](https://user-images.githubusercontent.com/69119241/224565324-8d04d02a-86c1-47fd-bb92-4cae32c679e0.png)

### After the PR:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/69119241/224565587-0c9448eb-041c-4624-9044-4a2f32fccc66.png">

