### PR TITLE
Fix: Correct always-false if condition in class-csv-import.php PHPStan

### DIFF
--- a/includes/admin/helpers/csv/class-csv-import.php
+++ b/includes/admin/helpers/csv/class-csv-import.php
@@ -653,7 +653,7 @@ class WPBDP_CSV_Import {
 			}
 		}
 
-		if ( $state->images ) {
+		if ( ! empty( $state->images[0] ) ) {
 			$listing->set_thumbnail_id( $state->images[0] );
 		}
 


### PR DESCRIPTION
This PR addresses an issue in the `includes/admin/helpers/csv/class-csv-import.php` file where an if condition was always evaluating to false during PHPStan checks.