### PR TITLE
Fix sticky posts for cats and shortcode

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -327,8 +327,10 @@ class WPBDP__Shortcodes {
 
 		$this->validate_attributes( $sc_atts, $atts );
 
-		$query_args                   = array();
-		$query_args['items_per_page'] = intval( $sc_atts['items_per_page'] );
+		$query_args = array(
+			'items_per_page'  => intval( $sc_atts['items_per_page'] ),
+			'wpbdp_shortcode' => true,
+		);
 
 		$this->process_category_atts( $sc_atts, $query_args );
 
@@ -375,6 +377,7 @@ class WPBDP__Shortcodes {
 			array(
 				'orderby' => 'date',
 				'order'   => 'DESC',
+				'wpbdp_shortcode' => true,
 			),
 			$sc_atts
 		);


### PR DESCRIPTION
Fix https://github.com/Strategy11/business-directory-premium/issues/181
Pass a query arg for BD shortcodess so we know whether to alter sitcky posts
This solves the problem for category pages, the businessdirectory-latest-listings shortcode, and businessdirectory-listings shortcode