### PR TITLE
Fix fatal error with Russian

### DIFF
--- a/includes/admin/controllers/class-admin-fees.php
+++ b/includes/admin/controllers/class-admin-fees.php
@@ -296,7 +296,7 @@ class WPBDP__Admin__Fees extends WPBDP__Admin__Controller {
 		$fee = $this->get_or_die();
 
 		if ( $fee->delete() ) {
-			wpbdp_admin_message( sprintf( _x( 'Plan "%s" deleted.', 'fees admin', 'business-directory-plugin' ), $fee->label ) );
+			wpbdp_admin_message( sprintf( __( 'Plan "%s" deleted.', 'business-directory-plugin' ), $fee->label ) );
 		}
 
 		return $this->_redirect( 'index' );

--- a/includes/admin/controllers/class-admin-listings.php
+++ b/includes/admin/controllers/class-admin-listings.php
@@ -362,7 +362,7 @@ class WPBDP_Admin_Listings {
 				if ( $latest_payment && $latest_payment->status ) {
 					$attributes['payment']  = '<span class="wpbdp-tag wpbdp-listing-attr-payment-' . esc_attr( $latest_payment->status ) . '">';
 					$attributes['payment'] .= sprintf(
-						esc_html_x( 'Payment %s', 'admin listings', 'business-directory-plugin' ),
+						esc_html__( 'Payment %s', 'business-directory-plugin' ),
 						esc_html( $latest_payment->get_status_label( $latest_payment->status ) )
 					);
 					$attributes['payment'] .= '</span>';

--- a/includes/admin/controllers/class-admin-payments.php
+++ b/includes/admin/controllers/class-admin-payments.php
@@ -31,7 +31,7 @@ class WPBDP__Admin__Payments extends WPBDP__Admin__Controller {
 						'<a>',
 						'<a href="' . esc_url( remove_query_arg( 'listing' ) ) . '">',
 						sprintf(
-							_x( 'You\'re seeing payments related to listing: "%1$s" (ID #%2$d). <a>Click here</a> to see all payments.', 'payments admin', 'business-directory-plugin' ),
+							__( 'You\'re seeing payments related to listing: "%1$s" (ID #%2$d). <a>Click here</a> to see all payments.', 'business-directory-plugin' ),
 							esc_html( $listing->get_title() ),
 							esc_html( $listing->get_id() )
 						)

--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -738,12 +738,12 @@ class WPBDP__Settings_Admin {
 		}
 
 		if ( 'renewal' == $event ) {
-			$summary = sprintf( _x( 'Sent when a listing (%s) is renewed.', 'expiration notices', 'business-directory-plugin' ), $recurring_modifier );
+			$summary = sprintf( __( 'Sent when a listing (%s) is renewed.', 'business-directory-plugin' ), $recurring_modifier );
 		}
 
 		if ( 'expiration' == $event ) {
 			if ( '0 days' == $relative_time ) {
-				$summary = sprintf( _x( 'Sent when a listing (%s) expires.', 'expiration notices', 'business-directory-plugin' ), $recurring_modifier );
+				$summary = sprintf( __( 'Sent when a listing (%s) expires.', 'business-directory-plugin' ), $recurring_modifier );
 			} else {
 				$relative_time_parts  = explode( ' ', $relative_time );
 				$relative_time_number = (int) trim( str_replace( array( '+', '-' ), '', $relative_time_parts[0] ) );
@@ -763,10 +763,10 @@ class WPBDP__Settings_Admin {
 
 				if ( $relative_time[0] == '+' ) {
 					/* translators: 1: relative time (e.g. 3 days), 2: recurring modifier (e.g. non-recuring only) */
-					$summary = sprintf( _x( 'Sent %1$s before a listing (%2$s) expires.', 'expiration notices', 'business-directory-plugin' ), $relative_time_h, $recurring_modifier );
+					$summary = sprintf( __( 'Sent %1$s before a listing (%2$s) expires.', 'business-directory-plugin' ), $relative_time_h, $recurring_modifier );
 				} else {
 					/* translators: 1: relative time (e.g. 3 days), 2: recurring modifier (e.g. non-recuring only) */
-					$summary = sprintf( _x( 'Sent %1$s after a listing (%2$s) expires.', 'expiration notices', 'business-directory-plugin' ), $relative_time_h, $recurring_modifier );
+					$summary = sprintf( __( 'Sent %1$s after a listing (%2$s) expires.', 'business-directory-plugin' ), $relative_time_h, $recurring_modifier );
 				}
 			}
 		}

--- a/includes/admin/csv-import.php
+++ b/includes/admin/csv-import.php
@@ -331,9 +331,8 @@ class WPBDP_CSVImportAdmin {
 		if ( ! $import_dir || ! is_dir( $import_dir ) || ! is_writable( $import_dir ) ) {
 			wpbdp_admin_message(
 				sprintf(
-					_x(
+					__(
 						'A valid temporary directory with write permissions is required for CSV imports to function properly. Your server is using "%s" but this path does not seem to be writable. Please consult with your host.',
-						'csv import',
 						'business-directory-plugin'
 					),
 					$import_dir

--- a/includes/admin/helpers/csv/class-csv-exporter.php
+++ b/includes/admin/helpers/csv/class-csv-exporter.php
@@ -109,7 +109,7 @@ class WPBDP_CSVExporter {
 					$direrror = _x( 'Could not create a temporary directory for handling this CSV export.', 'admin csv-export', 'business-directory-plugin' );
 					throw new Exception(
 						sprintf(
-							esc_html_x( 'Error while creating a temporary directory for CSV export: %s', 'admin csv-export', 'business-directory-plugin' ),
+							esc_html__( 'Error while creating a temporary directory for CSV export: %s', 'business-directory-plugin' ),
 							esc_html( $direrror )
 						)
 					);

--- a/includes/admin/helpers/csv/class-csv-import.php
+++ b/includes/admin/helpers/csv/class-csv-import.php
@@ -528,7 +528,7 @@ class WPBDP_CSV_Import {
 
 					$errors[] = $message;
 				} else {
-					$errors[] = sprintf( _x( 'Could not create listing category "%s"', 'admin csv-import', 'business-directory-plugin' ), $c['name'] );
+					$errors[] = sprintf( __( 'Could not create listing category "%s"', 'business-directory-plugin' ), $c['name'] );
 				}
 			}
 
@@ -721,7 +721,7 @@ class WPBDP_CSV_Import {
 				case 'username':
 					if ( $this->settings['assign-listings-to-user'] && $value ) {
 						if ( ! username_exists( $value ) ) {
-							$errors[] = sprintf( _x( 'Username "%s" does not exist', 'admin csv-import', 'business-directory-plugin' ), $value );
+							$errors[] = sprintf( __( 'Username "%s" does not exist', 'business-directory-plugin' ), $value );
 						} else {
 							$meta['username'] = $value;
 						}
@@ -782,7 +782,7 @@ class WPBDP_CSV_Import {
 					}
 
 					if ( $field->is_required() && $field->is_empty_value( $value ) ) {
-						$errors[] = sprintf( _x( 'Missing required field: %s', 'admin csv-import', 'business-directory-plugin' ), $column );
+						$errors[] = sprintf( __( 'Missing required field: %s', 'business-directory-plugin' ), $column );
 						break;
 					}
 
@@ -823,7 +823,7 @@ class WPBDP_CSV_Import {
 			}
 
 			if ( ! $this->settings['create-missing-categories'] ) {
-				$errors[] = sprintf( _x( 'Listing category "%s" does not exist', 'admin csv-import', 'business-directory-plugin' ), $csv_category );
+				$errors[] = sprintf( __( 'Listing category "%s" does not exist', 'business-directory-plugin' ), $csv_category );
 				continue;
 			}
 

--- a/includes/admin/helpers/tables/class-fees-table.php
+++ b/includes/admin/helpers/tables/class-fees-table.php
@@ -223,7 +223,7 @@ class WPBDP__Admin__Fees_Table extends WP_List_Table {
 			$amount = wpbdp_currency_format( $fee->amount );
 			$extra  = wpbdp_currency_format( $fee->pricing_details['extra'] );
 
-			return sprintf( _x( '%1$s + %2$s per category', 'fees admin', 'business-directory-plugin' ), $amount, $extra );
+			return sprintf( __( '%1$s + %2$s per category', 'business-directory-plugin' ), $amount, $extra );
 		}
 
 		$amount = $fee->amount ? wpbdp_currency_format( $fee->amount ) : '';

--- a/includes/admin/settings/class-settings-bootstrap.php
+++ b/includes/admin/settings/class-settings-bootstrap.php
@@ -1275,7 +1275,7 @@ final class WPBDP__Settings__Bootstrap {
 
 		return sprintf(
 			/* translators: %1$s: gateway name, %2$s: explanation string */
-			_x( 'AED currency is not supported by %1$s. %2$s', 'admin settings', 'business-directory-plugin' ),
+			__( 'AED currency is not supported by %1$s. %2$s', 'business-directory-plugin' ),
 			'<b>' . implode( ' or ', $aed_usupported_gateways ) . '</b>',
 			_n(
 				'If you are using this gateway, we recommend you disable it if you wish to collect payments in this currency.',
@@ -1463,10 +1463,10 @@ final class WPBDP__Settings__Bootstrap {
 					'subject' => '[[site-title]] Contact via "[listing]"',
 					'body'    => '' .
 								/* translators: %s: url shortcode */
-								sprintf( _x( 'You have received a reply from your listing at %s.', 'contact email', 'business-directory-plugin' ), '[listing-url]' ) . "\n\n" .
+								sprintf( __( 'You have received a reply from your listing at %s.', 'business-directory-plugin' ), '[listing-url]' ) . "\n\n" .
 
 								/* translators: %s: name shortcode */
-								sprintf( _x( 'Name: %s', 'contact email', 'business-directory-plugin' ), '[name]' ) . "\n" .
+								sprintf( __( 'Name: %s', 'business-directory-plugin' ), '[name]' ) . "\n" .
 
 								/* translators: %s: email shortcode */
 								sprintf( __( 'Email: %s', 'business-directory-plugin' ), '[email]' ) . "\n" .
@@ -1478,7 +1478,7 @@ final class WPBDP__Settings__Bootstrap {
 								'[message]' . "\n\n" .
 
 								/* translators: %s: date shortcode */
-								sprintf( _x( 'Time: %s', 'contact email', 'business-directory-plugin' ), '[date]' ),
+								sprintf( __( 'Time: %s', 'business-directory-plugin' ), '[date]' ),
 				),
 				'placeholders' => array(
 					'listing-url' => _x( 'Listing\'s URL', 'admin settings', 'business-directory-plugin' ),

--- a/includes/admin/upgrades/class-manual-upgrade-helper.php
+++ b/includes/admin/upgrades/class-manual-upgrade-helper.php
@@ -174,7 +174,7 @@ class WPBDP__Manual_Upgrade_Helper {
 				echo '<form action="" method="post">';
 				echo '<div class="wpbdp-manual-upgrade-configuration">';
 				echo $output;
-				echo '<div class="cf"><input type="submit" class="right button button-primary" value="' . _x( 'Continue', 'manual-upgrade', 'business-directory-plugin' ) . '"/></div>';
+				echo '<div class="cf"><input type="submit" class="right button button-primary" value="' . esc_attr__( 'Continue', 'business-directory-plugin' ) . '"/></div>';
 				echo '</div>';
 				echo '</form>';
 			}

--- a/includes/class-listing-email-notification.php
+++ b/includes/class-listing-email-notification.php
@@ -234,7 +234,7 @@ class WPBDP__Listing_Email_Notification {
 			$admin_email = new WPBDP_Email();
 
 			// translators: [%s] is the name of the blog.
-			$admin_email->subject = sprintf( _x( '[%s] New listing notification', 'notify email', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
+			$admin_email->subject = sprintf( __( '[%s] New listing notification', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
 			$admin_email->to[]    = get_bloginfo( 'admin_email' );
 
 			if ( wpbdp_get_option( 'admin-notifications-cc' ) ) {
@@ -302,7 +302,7 @@ class WPBDP__Listing_Email_Notification {
 		$email = new WPBDP_Email();
 
 		// translators: [%s] is the name of the blog.
-		$email->subject = sprintf( _x( '[%s] Listing edit notification', 'notify email', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
+		$email->subject = sprintf( __( '[%s] Listing edit notification', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
 		$email->to[]    = get_bloginfo( 'admin_email' );
 
 		if ( wpbdp_get_option( 'admin-notifications-cc' ) ) {
@@ -373,7 +373,7 @@ class WPBDP__Listing_Email_Notification {
 			$admin_email = new WPBDP_Email();
 
 			// translators: %s is the name of the blog.
-			$admin_email->subject = sprintf( _x( '[%s] Reported listing notification', 'notify email', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
+			$admin_email->subject = sprintf( __( '[%s] Reported listing notification', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
 			$admin_email->to[]    = get_bloginfo( 'admin_email' );
 
 			if ( wpbdp_get_option( 'admin-notifications-cc' ) ) {
@@ -420,7 +420,7 @@ class WPBDP__Listing_Email_Notification {
 			$admin_email = new WPBDP_Email();
 
 			// translators: [%s] is the name of the blog.
-			$admin_email->subject = sprintf( _x( '[%s] New payment notification', 'notify email', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
+			$admin_email->subject = sprintf( __( '[%s] New payment notification', 'business-directory-plugin' ), get_bloginfo( 'name' ) );
 			$admin_email->to[]    = get_bloginfo( 'admin_email' );
 
 			if ( wpbdp_get_option( 'admin-notifications-cc' ) ) {

--- a/includes/class-meta.php
+++ b/includes/class-meta.php
@@ -30,7 +30,7 @@ class WPBDP__Meta {
 		$feed_links      = array();
 
 		if ( 'main' === $current_view || 'all_listings' === $current_view ) {
-			$feed_title = sprintf( _x( '%s Feed', 'rss feed', 'business-directory-plugin' ), $main_page_title );
+			$feed_title = sprintf( __( '%s Feed', 'business-directory-plugin' ), $main_page_title );
 			$feed_url   = esc_url( add_query_arg( 'post_type', WPBDP_POST_TYPE, get_bloginfo( 'rss2_url' ) ) );
 
 			$feed_links[] = sprintf( $link_template, $feed_title, $feed_url );

--- a/includes/class-wpbdp.php
+++ b/includes/class-wpbdp.php
@@ -496,12 +496,12 @@ final class WPBDP {
 		$slots_available = 0;
 		$plan            = $listing->get_fee_plan();
 		if ( ! $plan ) {
-			return $res->send_error( _x( 'Please select a plan before uploading images to the listing', 'listing image upload', 'business-directory-plugin' ) );
+			return $res->send_error( __( 'Please select a plan before uploading images to the listing', 'business-directory-plugin' ) );
 		}
 
 		$slots_available = absint( $plan->fee_images ) - absint( $_POST['images_count'] );
 		if ( 0 >= $slots_available ) {
-			return $res->send_error( _x( 'Can not upload any more images for this listing.', 'listing image upload', 'business-directory-plugin' ) );
+			return $res->send_error( __( 'Can not upload any more images for this listing.', 'business-directory-plugin' ) );
 		} elseif ( $slots_available < count( $files ) ) {
 			return $res->send_error(
 				sprintf(

--- a/includes/helpers/class-fs.php
+++ b/includes/helpers/class-fs.php
@@ -125,7 +125,7 @@ final class WPBDP_FS {
 		if ( ! wp_is_writable( $destdir ) ) {
 			return new WP_Error(
 				'dest-not-writable',
-				sprintf( _x( 'Destination dir "%s" is not writable.', 'fs helper', 'business-directory-plugin' ), $destdir )
+				sprintf( __( 'Destination dir "%s" is not writable.', 'business-directory-plugin' ), $destdir )
 			);
 		}
 

--- a/includes/licensing.php
+++ b/includes/licensing.php
@@ -845,7 +845,7 @@ class WPBDP_Licensing {
 
 			$response = array(
 				'success' => false,
-				'error'   => sprintf( _x( 'Could not activate license: %s.', 'licensing', 'business-directory-plugin' ), $result->get_error_message() ),
+				'error'   => sprintf( __( 'Could not activate license: %s.', 'business-directory-plugin' ), $result->get_error_message() ),
 			);
 		} else {
 			$response = array(

--- a/includes/models/class-payment.php
+++ b/includes/models/class-payment.php
@@ -169,9 +169,9 @@ class WPBDP_Payment extends WPBDP__DB__Model {
 		}
 
 		if ( 'admin-submit' == $this->context ) {
-			$summary = sprintf( _x( '%s. Admin Posted.', 'payment summary', 'business-directory-plugin' ), $summary );
+			$summary = sprintf( __( '%s. Admin Posted.', 'business-directory-plugin' ), $summary );
 		} elseif ( 'csv-import' == $this->context ) {
-			$summary = sprintf( _x( '%s. Imported Listing.', 'payment summary', 'business-directory-plugin' ), $summary );
+			$summary = sprintf( __( '%s. Imported Listing.', 'business-directory-plugin' ), $summary );
 		}
 
 		return $summary;

--- a/templates/admin/themes-delete-confirm.tpl.php
+++ b/templates/admin/themes-delete-confirm.tpl.php
@@ -12,7 +12,7 @@ wpbdp_admin_header(
 <p>
 <?php
 printf(
-	_x( 'Are you sure you want to delete the directory theme "%s"?', 'themes admin', 'business-directory-plugin' ),
+	__( 'Are you sure you want to delete the directory theme "%s"?', 'business-directory-plugin' ),
 	$theme->name
 );
 ?>


### PR DESCRIPTION
This line was causing "Unknown format specifier" error:
`$feed_title = sprintf( _x( '%s Feed', 'rss feed', 'business-directory-plugin' ), $main_page_title );`

Changing 'rss feed' to 'rss' fixes the issue. It seems a combination of %s and a modifier name with a space is the problem, but not 100% sure. It might only happen with 'rss feed' as the name. Updating a few others just in case.