### PR TITLE
Fix reported Fatal Error (#236)

### DIFF
--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -107,7 +107,7 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 		$is_pending_payment = ( 'pending_payment' === $listing_status );
 		$payment_url        = $listing->get_payment_url();
 
-		if ( $payment_url !== null ) {
+		if ( $payment_url ) {
 			$buttons = sprintf(
 				'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
 				$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),

--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -108,13 +108,15 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 		$payment_url        = $listing->get_payment_url();
 		$show_button        = ! $is_pending_payment || $payment_url;
 
-		if ( $show_button ) {
-			$buttons = sprintf(
-				'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
-				$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
-				$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
-			) . $buttons;
+		if ( ! $show_button ) {
+			return $buttons;
 		}
+
+		$buttons = sprintf(
+			'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
+			$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
+			$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
+		) . $buttons;
 
 		return $buttons;
 	}

--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -105,12 +105,16 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 		}
 
 		$is_pending_payment = ( 'pending_payment' === $listing_status );
-		$buttons            = sprintf(
-			'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
-			$is_pending_payment ? esc_url( $listing->get_payment_url() ) : esc_url( $listing->get_renewal_url() ),
-			'target="_blank" rel="noopener"',
-			$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
-		) . $buttons;
+		$payment_url        = $listing->get_payment_url();
+
+		if ( $payment_url !== null ) {
+			$buttons = sprintf(
+				'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
+				$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
+				'target="_blank" rel="noopener"',
+				$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
+			) . $buttons;
+		}
 
 		return $buttons;
 	}

--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -104,15 +104,23 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 			return $buttons;
 		}
 
-		$is_pending_payment = ( 'pending_payment' === $listing_status );
-		$payment_url        = $listing->get_payment_url();
+		$is_pending  = ( 'pending_payment' === $listing_status );
+		$pending_url = $listing->get_payment_url();
+		$renewal_url = $listing->get_renewal_url();
 
-		$buttons = sprintf(
-			'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
-			$is_pending_payment && $payment_url ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
-			'target="_blank" rel="noopener"',
-			$is_pending_payment && $payment_url ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
-		) . $buttons;
+		if ( $is_pending && $pending_url ) {
+			$buttons = sprintf(
+				'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
+				esc_url( $pending_url ),
+				esc_html__( 'Pay Now', 'business-directory-plugin' )
+			) . $buttons;
+		} elseif ( ! $is_pending && $renewal_url ) {
+			$buttons = sprintf(
+				'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
+				esc_url( $renewal_url ),
+				esc_html__( 'Renew Listing', 'business-directory-plugin' )
+			) . $buttons;
+		}
 
 		return $buttons;
 	}

--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -104,21 +104,15 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 			return $buttons;
 		}
 
-		$is_pending  = ( 'pending_payment' === $listing_status );
-		$pending_url = $listing->get_payment_url();
-		$renewal_url = $listing->get_renewal_url();
+		$is_pending_payment = ( 'pending_payment' === $listing_status );
+		$payment_url        = $listing->get_payment_url();
+		$show_button        = ! $is_pending_payment || $payment_url;
 
-		if ( $is_pending && $pending_url ) {
+		if ( $show_button ) {
 			$buttons = sprintf(
 				'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
-				esc_url( $pending_url ),
-				esc_html__( 'Pay Now', 'business-directory-plugin' )
-			) . $buttons;
-		} elseif ( ! $is_pending && $renewal_url ) {
-			$buttons = sprintf(
-				'<a class="button wpbdp-button renew-listing" href="%s" target="_blank" rel="noopener">%s</a>',
-				esc_url( $renewal_url ),
-				esc_html__( 'Renew Listing', 'business-directory-plugin' )
+				$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
+				$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
 			) . $buttons;
 		}
 

--- a/includes/controllers/pages/class-manage-listings.php
+++ b/includes/controllers/pages/class-manage-listings.php
@@ -107,14 +107,12 @@ class WPBDP__Views__Manage_Listings extends WPBDP__View {
 		$is_pending_payment = ( 'pending_payment' === $listing_status );
 		$payment_url        = $listing->get_payment_url();
 
-		if ( $payment_url ) {
-			$buttons = sprintf(
-				'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
-				$is_pending_payment ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
-				'target="_blank" rel="noopener"',
-				$is_pending_payment ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
-			) . $buttons;
-		}
+		$buttons = sprintf(
+			'<a class="button wpbdp-button renew-listing" href="%s" %s >%s</a>',
+			$is_pending_payment && $payment_url ? esc_url( $payment_url ) : esc_url( $listing->get_renewal_url() ),
+			'target="_blank" rel="noopener"',
+			$is_pending_payment && $payment_url ? esc_html__( 'Pay Now', 'business-directory-plugin' ) : esc_html__( 'Renew Listing', 'business-directory-plugin' )
+		) . $buttons;
 
 		return $buttons;
 	}

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -621,7 +621,7 @@ class WPBDP_Listing {
 	 */
 	public function get_payment_url() {
 		$payment = $this->get_latest_payment();
-		return $payment !== null ? $payment->get_checkout_url() : null;
+		return is_object( $payment ) && method_exists( $payment, 'get_checkout_url' ) ? $payment->get_checkout_url() : null;
 	}
 
 	/**

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -621,7 +621,7 @@ class WPBDP_Listing {
 	 */
 	public function get_payment_url() {
 		$payment = $this->get_latest_payment();
-		return $payment->get_checkout_url();
+		return $payment !== null ? $payment->get_checkout_url() : null;
 	}
 
 	/**

--- a/includes/models/class-listing.php
+++ b/includes/models/class-listing.php
@@ -621,7 +621,7 @@ class WPBDP_Listing {
 	 */
 	public function get_payment_url() {
 		$payment = $this->get_latest_payment();
-		return is_object( $payment ) && method_exists( $payment, 'get_checkout_url' ) ? $payment->get_checkout_url() : null;
+		return is_object( $payment ) && method_exists( $payment, 'get_checkout_url' ) ? $payment->get_checkout_url() : '';
 	}
 
 	/**


### PR DESCRIPTION
`get_latest_payment()` can return null, but was not checked for that, so it caused a fatal error in the scenario when it is not an object.