### PR TITLE
Converts http to https

### DIFF
--- a/includes/fields/class-fieldtypes-url.php
+++ b/includes/fields/class-fieldtypes-url.php
@@ -141,7 +141,8 @@ class WPBDP_FieldTypes_URL extends WPBDP_Form_Field_Type {
 		}
 
 		// Adds the http protocol if it's missing.
-		$url  = esc_url_raw( is_array( $input ) ? trim( $input[0] ) : $input );
+		$url_raw = esc_url_raw( is_array( $input ) ? trim( $input[0] ) : $input );
+		$url = is_ssl() ? str_replace( 'http://', 'https://', $url_raw ) : $url_raw;
 		$text = trim( is_array( $input ) ? sanitize_text_field( $input[1] ) : '' );
 
 		return array( $url, $text );

--- a/includes/fields/class-fieldtypes-url.php
+++ b/includes/fields/class-fieldtypes-url.php
@@ -140,7 +140,7 @@ class WPBDP_FieldTypes_URL extends WPBDP_Form_Field_Type {
 			return array( '', '' );
 		}
 
-		// Adds the http protocol if it's missing.
+		// Adds the http or https protocol, if it's missing.
 		$url_raw = esc_url_raw( is_array( $input ) ? trim( $input[0] ) : $input );
 		$url     = is_ssl() ? str_replace( 'http://', 'https://', $url_raw ) : $url_raw;
 		$text    = trim( is_array( $input ) ? sanitize_text_field( $input[1] ) : '' );

--- a/includes/fields/class-fieldtypes-url.php
+++ b/includes/fields/class-fieldtypes-url.php
@@ -142,8 +142,8 @@ class WPBDP_FieldTypes_URL extends WPBDP_Form_Field_Type {
 
 		// Adds the http protocol if it's missing.
 		$url_raw = esc_url_raw( is_array( $input ) ? trim( $input[0] ) : $input );
-		$url = is_ssl() ? str_replace( 'http://', 'https://', $url_raw ) : $url_raw;
-		$text = trim( is_array( $input ) ? sanitize_text_field( $input[1] ) : '' );
+		$url     = is_ssl() ? str_replace( 'http://', 'https://', $url_raw ) : $url_raw;
+		$text    = trim( is_array( $input ) ? sanitize_text_field( $input[1] ) : '' );
 
 		return array( $url, $text );
 	}


### PR DESCRIPTION
WordPress [appends http ](https://github.com/WordPress/wordpress-develop/blob/e8fed338f8f27363cb24f0ea2792cfa3b311b612/src/wp-includes/formatting.php#L4515)to santized urls. This converts that to https when we save our URL fields for sites that use SSL.

Fixes https://github.com/Strategy11/business-directory-premium/issues/228
