### PR TITLE
Check if the value is empty before adding https://

### DIFF
--- a/includes/fields/class-fieldtypes-url.php
+++ b/includes/fields/class-fieldtypes-url.php
@@ -144,7 +144,7 @@ class WPBDP_FieldTypes_URL extends WPBDP_Form_Field_Type {
         $has_protocol = str_contains( $raw_url, 'http://' ) || str_contains( $raw_url, 'https://' );
 
         // Check if the URL has a protocol, if not, add https.
-        if ( ! $has_protocol ) {
+        if ( ! empty( $raw_url ) && ! $has_protocol ) {
             $raw_url = 'https://' . $raw_url;
         }
 


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/228

This PR adds a check for the value of the URL field, if it is empty it doesn't add the https:// protocol.