### PR TITLE
Add no renewal email error message

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -1075,17 +1075,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 						break;
 					}
 
-					$all_notices      = wpbdp_get_option( 'expiration-notices' );
-					$recurring_notice = false;
-
-					foreach ( $all_notices as $notice ) {
-						if ( 'recurring' === $notice['listings'] ) {
-							$recurring_notice = true;
-							break;
-						}
-					}
-
-					if ( $listing->is_recurring() && ! $recurring_notice ) {
+					if ( $listing->is_recurring() && ! $this->recurring_renewal_notices() ) {
 						$this->messages[] = array( __( 'No renewal emails found.', 'business-directory-plugin' ), 'error' );
 						break;
 					}
@@ -1112,6 +1102,27 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			}
 
 			$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'wpbdmaction', 'wpbdmfilter', 'transaction_id', 'category_id', 'fee_id', 'u', 'renewal_id', 'flagging_user' ), wpbdp_get_server_value( 'REQUEST_URI' ) );
+		}
+
+		/**
+		 * Check if there are any recurring renewal notices.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return bool
+		 */
+		private function recurring_renewal_notices() {
+			$all_notices      = wpbdp_get_option( 'expiration-notices' );
+			$recurring_notice = false;
+
+			foreach ( $all_notices as $notice ) {
+				if ( 'recurring' === $notice['listings'] ) {
+					$recurring_notice = true;
+					break;
+				}
+			}
+
+			return $recurring_notice;
 		}
 
 		private function send_access_keys( $posts ) {

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -1079,7 +1079,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 					$recurring_notice = false;
 
 					foreach ( $all_notices as $notice ) {
-						if ( ( 'recurring' === $notice['listings'] ) ) {
+						if ( 'recurring' === $notice['listings'] ) {
 							$recurring_notice = true;
 						}
 					}

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -939,7 +939,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 				return;
 			}
 
-			//_deprecated_function( __METHOD__, '5.15.3', 'The classes in an admin notice are outdated: ' . $class );
+			// _deprecated_function( __METHOD__, '5.15.3', 'The classes in an admin notice are outdated: ' . $class );
 			$classes = str_replace( $find, $replace, $classes );
 			$class   = implode( ' ', $classes );
 		}
@@ -1075,6 +1075,20 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 						break;
 					}
 
+					$all_notices      = wpbdp_get_option( 'expiration-notices' );
+					$recurring_notice = false;
+
+					foreach ( $all_notices as $notice ) {
+						if ( ( 'recurring' === $notice['listings'] ) ) {
+							$recurring_notice = true;
+						}
+					}
+
+					if ( $listing->is_recurring() && ! $recurring_notice ) {
+						$this->messages[] = array( __( 'No renewal emails found.', 'business-directory-plugin' ), 'error' );
+						break;
+					}
+
 					$this->messages[] = array( __( 'Could not send renewal email.', 'business-directory-plugin' ), 'error' );
 
 					break;
@@ -1140,7 +1154,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 
 			// TODO: Redirect and show messages on page load.
 			// if ( wp_redirect( remove_query_arg( array( 'action', 'post', 'wpbdmaction' ) ) ) ) {
-			//     exit();
+			// exit();
 			// }
 		}
 

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -1081,6 +1081,7 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 					foreach ( $all_notices as $notice ) {
 						if ( 'recurring' === $notice['listings'] ) {
 							$recurring_notice = true;
+							break;
 						}
 					}
 


### PR DESCRIPTION
closes https://github.com/Strategy11/business-directory-premium/issues/224

This PR adds a new error message if the user doesn't have any recurring email templates when they press the `Send renewal email` button.