### PR TITLE
Prevent caching null

### DIFF
--- a/includes/helpers/functions/general.php
+++ b/includes/helpers/functions/general.php
@@ -525,7 +525,7 @@ function wpbdp_date( $timestamp ) {
 /**
  * @since 3.5.3
  */
-function wpbdp_get_post_by_id_or_slug( $id_or_slug = false, $try_first = 'id', $result = 'post' ) {
+function wpbdp_get_post_by_id_or_slug( $id_or_slug = false, $try_first = 'id', $result = 'post', $allow_empty = true ) {
 	if ( 'slug' === $try_first ) {
 		$strategies = array( 'post_name', 'ID' );
 	} else {
@@ -544,7 +544,8 @@ function wpbdp_get_post_by_id_or_slug( $id_or_slug = false, $try_first = 'id', $
 				'group'     => 'wpbdp_listings',
 				'query'     => $q,
 				'type'      => 'get_var',
-			)
+			),
+			$allow_empty
 		);
 		$listing_id = intval( $listing_id );
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -107,7 +107,7 @@ class WPBDP_Utils {
 	 *
 	 * @return mixed $results The cache or query results
 	 */
-	public static function check_cache( $args ) {
+	public static function check_cache( $args, $allow_empty = true ) {
 		$defaults = array(
 			'cache_key' => '',
 			'group'     => '',
@@ -144,7 +144,7 @@ class WPBDP_Utils {
 			}
 		}
 
-		if ( ! empty( $results ) ) {
+		if ( $allow_empty || ! empty( $results ) ) {
 			self::set_cache( $args['cache_key'], $results, $args['group'], $args['time'] );
 		}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -144,7 +144,9 @@ class WPBDP_Utils {
 			}
 		}
 
-		self::set_cache( $args['cache_key'], $results, $args['group'], $args['time'] );
+		if ( ! empty( $results ) ) {
+			self::set_cache( $args['cache_key'], $results, $args['group'], $args['time'] );
+		}
 
 		return $results;
 	}


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/257

This PR adds a check before the `set_cache` method to make sure we don't save an empty value in cache if that is enabled when the `check_cache` is called.

And also it adds the `$allow_empty` parameter to `wpbdp_get_post_by_id_or_slug()` to give the option to ignore the empty values.