### PR TITLE
Change tip label to Install now if user has license

### DIFF
--- a/includes/admin/class-education.php
+++ b/includes/admin/class-education.php
@@ -201,14 +201,14 @@ class WPBDP_Admin_Education {
 	 */
 	private static function has_access_to( $module ) {
 		$licenses = get_option( 'wpbdp_licenses', array() );
-		
-		if ( ! isset( $licenses[ 'module-business-directory-' . $module ] ) ) {
+
+		if ( ! is_array( $licenses ) || ! isset( $licenses[ 'module-business-directory-' . $module ] ) ) {
 			return false;
 		}
 
 		$license = $licenses[ 'module-business-directory-' . $module ];
 
-		if ( ! isset( $license['status'] ) || $license['status'] !== 'valid' ) {
+		if ( ! is_array( $license ) || ! isset( $license['status'] ) || $license['status'] !== 'valid' ) {
 			return false;
 		}
 

--- a/includes/admin/class-education.php
+++ b/includes/admin/class-education.php
@@ -211,17 +211,8 @@ class WPBDP_Admin_Education {
 	 */
 	private static function has_access_to( $module ) {
 		$licenses = get_option( 'wpbdp_licenses', array() );
-
-		if ( ! is_array( $licenses ) || ! isset( $licenses[ 'module-business-directory-' . $module ] ) ) {
-			return false;
-		}
-
-		$license = $licenses[ 'module-business-directory-' . $module ];
-
-		if ( ! is_array( $license ) || ! isset( $license['status'] ) || $license['status'] !== 'valid' ) {
-			return false;
-		}
-
-		return true;
+		$license  = isset( $licenses[ 'module-business-directory-' . $module ] ) ? $licenses[ 'module-business-directory-' . $module ] : null;
+	
+		return is_array( $license ) && isset( $license['status'] ) && $license['status'] === 'valid';
 	}
 }

--- a/includes/admin/class-education.php
+++ b/includes/admin/class-education.php
@@ -201,13 +201,17 @@ class WPBDP_Admin_Education {
 	 */
 	private static function has_access_to( $module ) {
 		$licenses = get_option( 'wpbdp_licenses', array() );
+		
 		if ( ! isset( $licenses[ 'module-business-directory-' . $module ] ) ) {
 			return false;
 		}
+
 		$license = $licenses[ 'module-business-directory-' . $module ];
+
 		if ( ! isset( $license['status'] ) || $license['status'] !== 'valid' ) {
 			return false;
 		}
+
 		return true;
 	}
 }

--- a/includes/admin/class-education.php
+++ b/includes/admin/class-education.php
@@ -161,7 +161,7 @@ class WPBDP_Admin_Education {
 		}
 
 		$is_any_upgrade = $tip['cta'] === 'Upgrade Now.' || $tip['cta'] === 'Upgrade to Premium';
-		if ( $has_premium && $is_any_upgrade ) {
+		if ( ( $has_premium && $is_any_upgrade ) || self::has_access_to( $tip['requires'] ) ) {
 			$tip['cta']  = 'Install Now.';
 			$tip['link'] = admin_url( 'admin.php?page=wpbdp-addons' );
 		}
@@ -190,5 +190,24 @@ class WPBDP_Admin_Education {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if the user has access to a module
+	 *
+	 * @param string $module
+	 * 
+	 * @return bool
+	 */
+	private static function has_access_to( $module ) {
+		$licenses = get_option( 'wpbdp_licenses', array() );
+		if ( ! isset( $licenses[ 'module-business-directory-' . $module ] ) ) {
+			return false;
+		}
+		$license = $licenses[ 'module-business-directory-' . $module ];
+		if ( ! isset( $license['status'] ) || $license['status'] !== 'valid' ) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/includes/admin/class-education.php
+++ b/includes/admin/class-education.php
@@ -160,8 +160,18 @@ class WPBDP_Admin_Education {
 			return array();
 		}
 
-		$is_any_upgrade = $tip['cta'] === 'Upgrade Now.' || $tip['cta'] === 'Upgrade to Premium';
-		if ( ( $has_premium && $is_any_upgrade ) || self::has_access_to( $tip['requires'] ) ) {
+		$upgrade_labels = array( 
+			'Upgrade Now.', 
+			'Upgrade to Premium', 
+			'Upgrade to Pro.',
+		);
+
+		$is_any_upgrade = in_array( $tip['cta'], $upgrade_labels, true );
+
+		$is_premium_cta = $is_any_upgrade && $has_premium;
+		$is_pro_cta     = $is_any_upgrade && self::has_access_to( $tip['requires'] );
+
+		if ( $is_premium_cta || $is_pro_cta ) {
 			$tip['cta']  = 'Install Now.';
 			$tip['link'] = admin_url( 'admin.php?page=wpbdp-addons' );
 		}


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/134

This PR adds a method that checks if the current license has access to the module that's recommended in the tips and if it does it changes the label from download to install.