### PR TITLE
Fix deprecated use of get_class in PHP 8.4

### DIFF
--- a/includes/models/class-payment.php
+++ b/includes/models/class-payment.php
@@ -419,7 +419,7 @@ class WPBDP_Payment extends WPBDP__DB__Model {
 	 * @override
 	 */
 	public static function objects() {
-		return parent::_objects( get_class() );
+		return parent::_objects( __CLASS__ );
 	}
 
 	/**


### PR DESCRIPTION
I'm running PHP 8.4 RC2 right now locally.

This PR fixes a new deprecated message that is introduced in PHP 8.4.

> PHP Deprecated:  Calling get_class() without arguments is deprecated in /var/www/src/wp-content/plugins/business-directory-plugin/includes/models/class-payment.php on line 422

Calling `get_class()` with no arguments in a static function appears to work the same as using `__CLASS__`.