### PR TITLE
Fix deprecated null param in number format in PHP 8.4

### DIFF
--- a/includes/helpers/class-currency-helper.php
+++ b/includes/helpers/class-currency-helper.php
@@ -56,6 +56,9 @@ class WPBDP_Currency_Helper {
 			if ( is_string( $amount ) ) {
 				$amount = floatval( self::prepare_price( $amount, $currency ) );
 			}
+			if ( is_null( $amount ) ) {
+				$amount = 0;
+			}
 			$amount = number_format( $amount, $currency['decimals'], $currency['decimal_separator'], $currency['thousand_separator'] );
 		}
 

--- a/includes/helpers/class-currency-helper.php
+++ b/includes/helpers/class-currency-helper.php
@@ -57,7 +57,7 @@ class WPBDP_Currency_Helper {
 				$amount = floatval( self::prepare_price( $amount, $currency ) );
 			}
 			if ( is_null( $amount ) ) {
-				$amount = 0;
+				$amount = 0.0;
 			}
 			$amount = number_format( $amount, $currency['decimals'], $currency['decimal_separator'], $currency['thousand_separator'] );
 		}


### PR DESCRIPTION
Using PHP 8.4 RC2, I see this deprecated message.

This update checks if `$num` is null, and if it is, converts it to a safe float value first.

> PHP Deprecated:  number_format(): Passing null to parameter #1 ($num) of type float is deprecated in /var/www/src/wp-content/plugins/business-directory-plugin/includes/helpers/class-currency-helper.php on line 62