### PR TITLE
Fix php warning on email templates page

### DIFF
--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -610,10 +610,15 @@ class WPBDP__Settings_Admin {
 		$this->setting_text_callback( $setting, $value );
 	}
 
+	/**
+	 * @param array|false $setting
+	 * @param mixed       $value
+	 * @return void
+	 */
 	public function setting_email_template_callback( $setting, $value ) {
 		if ( ! is_array( $value ) ) {
 			$value = array(
-				'subject' => $setting['default']['subject'],
+				'subject' => is_array( $setting['default'] ) && isset( $setting['default']['subject'] ) ? $setting['default']['subject'] : '',
 				'body'    => $value,
 			);
 		}

--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -611,8 +611,8 @@ class WPBDP__Settings_Admin {
 	}
 
 	/**
-	 * @param array|false $setting
-	 * @param mixed       $value
+	 * @param array $setting
+	 * @param mixed $value
 	 * @return void
 	 */
 	public function setting_email_template_callback( $setting, $value ) {

--- a/includes/admin/controllers/class-settings-admin.php
+++ b/includes/admin/controllers/class-settings-admin.php
@@ -613,6 +613,7 @@ class WPBDP__Settings_Admin {
 	/**
 	 * @param array $setting
 	 * @param mixed $value
+	 *
 	 * @return void
 	 */
 	public function setting_email_template_callback( $setting, $value ) {


### PR DESCRIPTION
When loading the email template settings page (/wp-admin/admin.php?page=wpbdp_settings&tab=email&subtab=email_templates), I see this PHP warning.

> PHP Warning:  Trying to access array offset on false in /var/www/src/wp-content/plugins/business-directory-plugin/includes/admin/controllers/class-settings-admin.php on line 616

This update just checks that `$setting['default']` is actually an array first, and that the key set. In my case, it was `false`.

There might be a better way to do this, or we might not want to use an empty string here as a fallback? I'm just avoiding the warning and haven't looked too much into this.