### PR TITLE
Allow dynamic properties in WPBDP__View

### DIFF
--- a/includes/abstracts/class-view.php
+++ b/includes/abstracts/class-view.php
@@ -10,6 +10,7 @@
 /**
  * Class WPBDP__View
  */
+#[\AllowDynamicProperties]
 class WPBDP__View {
 
 	public function __construct( $args = null ) {


### PR DESCRIPTION
This fixes a deprecated message I see when testing a BD shortcode.

> PHP Deprecated:  Creation of dynamic property WPBDP__Views__Manage_Listings::$show_search_bar is deprecated in /var/www/src/wp-content/plugins/business-directory-plugin/includes/abstracts/class-view.php on line 18

The code looks dynamic, so i think we want to just add the attribute to the class.