### PR TITLE
Add Readme Github Action

### DIFF
--- a/.github/workflows/push-deploy-readme.yml
+++ b/.github/workflows/push-deploy-readme.yml
@@ -1,0 +1,20 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - master
+jobs:
+  master:
+    name: Push to master
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Subversion
+      run: sudo apt-get update && sudo apt-get install -y subversion
+
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: business-directory-plugin


### PR DESCRIPTION
This PR adds a workflow that pushes readme changes to WordPress without pushing a new version.