### PR TITLE
Prevent Elementor from loading element cache on shortcodes

### DIFF
--- a/includes/compatibility/class-compat.php
+++ b/includes/compatibility/class-compat.php
@@ -149,14 +149,10 @@ class WPBDP_Compat {
 		}
 
 		$cache_key  = Elementor\Core\Base\Document::CACHE_META_KEY;
-		$shortcodes = array_keys( $wpbdp->shortcodes->get_shortcodes() );
+		$shortcodes = get_shortcode_regex( array_keys( $wpbdp->shortcodes->get_shortcodes() ) );
 
-		foreach ( $shortcodes as $shortcode ) {
-			if ( has_shortcode( $post->post_content, $shortcode ) ) {
-				delete_post_meta( $post->ID, $cache_key );
-			}
-
-			break;
+		if ( preg_match( "/$shortcodes/", $post->post_content ) ) {
+		    delete_post_meta( $post->ID, $cache_key );
 		}
 	}
 

--- a/includes/compatibility/class-compat.php
+++ b/includes/compatibility/class-compat.php
@@ -64,6 +64,11 @@ class WPBDP_Compat {
 			add_filter(
                 'wpf_skip_auto_login', array( $this, 'wp_fusion_skip_auto_login' ), 20 );
 		}
+
+		// Delete Elementor element caching for shortcodes.
+		if ( class_exists( 'Elementor\Core\Base\Document' ) ) {
+			add_action( 'template_redirect', array( $this, 'prevent_shortcodes_elementor_element_cache' ) );
+		}
 	}
 
 	public function cpt_compat_mode() {
@@ -127,6 +132,32 @@ class WPBDP_Compat {
 			return true;
 		}
 		return $skip_auto_login;
+	}
+
+	/**
+	 * Checks if the current post content has a BD shortcode and deletes the Elementor cache.
+	 * 
+	 * @since x.x
+	 *
+	 * @return void
+	 */
+	public function prevent_shortcodes_elementor_element_cache() {
+		global $post, $wpbdp;
+
+		if ( ! $post ) {
+			return;
+		}
+
+		$cache_key = Elementor\Core\Base\Document::CACHE_META_KEY;
+		$shortcodes = array_keys( $wpbdp->shortcodes->get_shortcodes() );
+
+		foreach ( $shortcodes as $shortcode ) {
+			if ( has_shortcode( $post->post_content, $shortcode ) ) {
+				delete_post_meta( $post->ID, $cache_key );
+			}
+
+			break;
+		}
 	}
 
     /**

--- a/includes/compatibility/class-compat.php
+++ b/includes/compatibility/class-compat.php
@@ -148,7 +148,7 @@ class WPBDP_Compat {
 			return;
 		}
 
-		$cache_key = Elementor\Core\Base\Document::CACHE_META_KEY;
+		$cache_key  = Elementor\Core\Base\Document::CACHE_META_KEY;
 		$shortcodes = array_keys( $wpbdp->shortcodes->get_shortcodes() );
 
 		foreach ( $shortcodes as $shortcode ) {

--- a/stubs.php
+++ b/stubs.php
@@ -117,3 +117,9 @@ namespace WPMailSMTP {
 		}
 	}
 }
+
+namespace Elementor\Core\Base {
+	class Document {
+		public const CACHE_META_KEY = '_elementor_element_cache';
+	}	
+}


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/269

This PR checks if Elementor is active and if the current post has one of our shortcodes. If it has any shortcode it will delete the current element cache value to make sure we always render the right page.