### PR TITLE
Remove spaces from sorting

### DIFF
--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -221,8 +221,8 @@ class WPBDP__Query_Integration {
 		}
 
 		$field = explode( ' ', $orderby )[0];
-		
-		return "REPLACE({$field}, ' ', '') " . $query->get( 'order', 'ASC' );
+
+		return $this->get_space_replace( $field, $query->get( 'order', 'ASC' ) );
 	}
 
 	/**
@@ -489,10 +489,24 @@ class WPBDP__Query_Integration {
 		}
 
 		if ( $qn && $qn !== $orderby ) {
-			$orderby = $orderby . ( $orderby ? ', ' : '' ) . "REPLACE({$qn}, ' ', '') " . ' ' . $sort->order;
+			$orderby = $orderby . ( $orderby ? ', ' : '' ) . $this->get_space_replace( $qn, $sort->order );
 		}
 
 		return $orderby;
+	}
+
+	/**
+	 * Return the space removal string for the given field and order.
+	 * 
+	 * @since x.x
+	 *
+	 * @param string $field - The field to remove spaces from.
+	 * @param string $order - The order to apply.
+	 * 
+	 * @return string
+	 */
+	private function get_space_replace( $field, $order ) {
+		return "REPLACE({$field}, ' ', '') " . ' ' . $order;
 	}
 
 	/**

--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -201,6 +201,7 @@ class WPBDP__Query_Integration {
 			add_filter( 'posts_results', array( $this, 'check_child_page' ), 10, 2 );
 		}
 
+		// Remove spaces from orderby in the default query.
 		add_filter( 'posts_orderby', array( $this, 'remove_spaces_from_order_by' ), 10, 2 );
 	}
 
@@ -488,7 +489,7 @@ class WPBDP__Query_Integration {
 		}
 
 		if ( $qn && $qn !== $orderby ) {
-			$orderby = $orderby . ( $orderby ? ', ' : '' ) . $qn . ' ' . $sort->order;
+			$orderby = "REPLACE({$qn}, ' ', '') " . $sort->order;
 		}
 
 		return $orderby;

--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -489,7 +489,7 @@ class WPBDP__Query_Integration {
 		}
 
 		if ( $qn && $qn !== $orderby ) {
-			$orderby = "REPLACE({$qn}, ' ', '') " . $sort->order;
+			$orderby = $orderby . ( $orderby ? ', ' : '' ) . "REPLACE({$qn}, ' ', '') " . ' ' . $sort->order;
 		}
 
 		return $orderby;

--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -200,6 +200,28 @@ class WPBDP__Query_Integration {
 		} elseif ( 'show_listing' === $query->wpbdp_view && $query->is_main_query() ) {
 			add_filter( 'posts_results', array( $this, 'check_child_page' ), 10, 2 );
 		}
+
+		add_filter( 'posts_orderby', array( $this, 'remove_spaces_from_order_by' ), 10, 2 );
+	}
+
+	/**
+	 * Filter the posts orderby clause to remove spaces for improved sorting.
+	 * 
+	 * @since x.x
+	 *
+	 * @param string   $orderby - The orderby clause.
+	 * @param WP_Query $query - The current query object.
+	 *
+	 * @return string
+	 */
+	public function remove_spaces_from_order_by( $orderby, $query ) {
+		if ( ! isset( $query->wpbdp_our_query ) || ! $query->wpbdp_our_query ) {
+			return $orderby;
+		}
+
+		$field = explode( ' ', $orderby )[0];
+		
+		return "REPLACE({$field}, ' ', '') " . $query->get( 'order', 'ASC' );
 	}
 
 	/**

--- a/includes/class-query-integration.php
+++ b/includes/class-query-integration.php
@@ -216,7 +216,7 @@ class WPBDP__Query_Integration {
 	 * @return string
 	 */
 	public function remove_spaces_from_order_by( $orderby, $query ) {
-		if ( ! isset( $query->wpbdp_our_query ) || ! $query->wpbdp_our_query ) {
+		if ( empty( $query->wpbdp_our_query ) ) {
 			return $orderby;
 		}
 
@@ -506,7 +506,7 @@ class WPBDP__Query_Integration {
 	 * @return string
 	 */
 	private function get_space_replace( $field, $order ) {
-		return "REPLACE({$field}, ' ', '') " . ' ' . $order;
+		return "REPLACE( {$field}, ' ', '' ) " . ' ' . $order;
 	}
 
 	/**


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/263

This PR adds a filter to the query order by clause to remove spaces from the value to improve sorting both in the initial query that renders the first page and if the user changes the sorting order.