### PR TITLE
Store the field label to allow for translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 .site/
 _vvv/
 .idea/
+.vscode/
 
 # PHP CS Fixer
 .php-cs-fixer.cache

--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -116,7 +116,7 @@ class WPBDP_Form_Field_Type {
 	 *
 	 * @param WPBDP_Form_Field_Type $field The field object.
 	 * 
-	 * @return null|string
+	 * @return string|null
 	 */
 	public function get_field_selected_value( &$field ) {
 		// phpcs:ignore

--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -109,6 +109,33 @@ class WPBDP_Form_Field_Type {
 		return $value;
 	}
 
+	/**
+	 * Retrieve the option name for the selected value.
+	 * 
+	 * @since x.x
+	 *
+	 * @param WPBDP_Form_Field_Type $field The field object.
+	 * 
+	 * @return null|string
+	 */
+	public function get_field_selected_value( &$field ) {
+		// phpcs:ignore
+		if ( empty( $_GET['listing_id'] ) && empty( $_GET['post'] ) ) {
+			return null;
+		}
+
+		// phpcs:ignore
+		$post_id = ! empty( $_GET['listing_id'] ) ? intval( $_GET['listing_id'] ) : intval( $_GET['post'] );
+
+		$value = get_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', true );
+
+		if ( false === $value ) {
+			return null;
+		}
+
+		return $value;
+	}
+
 	public function get_field_html_value( &$field, $post_id ) {
 		$post = get_post( $post_id );
 
@@ -200,6 +227,29 @@ class WPBDP_Form_Field_Type {
 
 		if ( count( $update_post ) > 1 ) {
 			wp_update_post( $update_post );
+		}
+	}
+
+	/**
+	 * Store the selected value for the field.
+	 * 
+	 * @since x.x
+	 *
+	 * @param WPBDP_Form_Field_Type $field   The field object.
+	 * @param int|string            $post_id The post ID.
+	 * @param string                $value   The value to store.
+	 * 
+	 * @return void
+	 */
+	protected function store_field_selected_value( &$field, $post_id, $value ) {
+		if ( ! method_exists( $field, 'data' ) ) {
+			return;
+		}
+
+		$option = array_search( $value, $field->data()['options'], true );
+
+		if ( false !== $option ) {
+			update_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', $option );
 		}
 	}
 

--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -126,7 +126,7 @@ class WPBDP_Form_Field_Type {
 			return null;
 		}
 
-		$post_id = ! empty( $listing_id ) ? intval( $listing_param ) : intval( $post_param );
+		$post_id = ! empty( $listing_param ) ? intval( $listing_param ) : intval( $post_param );
 		$value   = get_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', true );
 
 		if ( false === $value ) {

--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -119,15 +119,15 @@ class WPBDP_Form_Field_Type {
 	 * @return string|null
 	 */
 	public function get_field_selected_value( &$field ) {
-		// phpcs:ignore
-		if ( empty( $_GET['listing_id'] ) && empty( $_GET['post'] ) ) {
+		$listing_param = wpbdp_get_var( array( 'param' => 'listing_id' ), 'get' );
+		$post_param    = wpbdp_get_var( array( 'param' => 'post' ), 'get' );
+
+		if ( empty( $listing_param ) && empty( $post_param ) ) {
 			return null;
 		}
 
-		// phpcs:ignore
-		$post_id = ! empty( $_GET['listing_id'] ) ? intval( $_GET['listing_id'] ) : intval( $_GET['post'] );
-
-		$value = get_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', true );
+		$post_id = ! empty( $listing_id ) ? intval( $listing_param ) : intval( $post_param );
+		$value   = get_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', true );
 
 		if ( false === $value ) {
 			return null;

--- a/includes/abstracts/class-form-field-type.php
+++ b/includes/abstracts/class-form-field-type.php
@@ -129,11 +129,7 @@ class WPBDP_Form_Field_Type {
 		$post_id = ! empty( $listing_param ) ? intval( $listing_param ) : intval( $post_param );
 		$value   = get_post_meta( $post_id, '_wpbdp[fields][' . $field->get_id() . ']_selected', true );
 
-		if ( false === $value ) {
-			return null;
-		}
-
-		return $value;
+		return false !== $value ? $value : null;
 	}
 
 	public function get_field_html_value( &$field, $post_id ) {

--- a/includes/fields/class-fieldtypes-radiobutton.php
+++ b/includes/fields/class-fieldtypes-radiobutton.php
@@ -86,6 +86,17 @@ class WPBDP_FieldTypes_RadioButton extends WPBDP_Form_Field_Type {
 		return $html;
 	}
 
+	/**
+	 * Extend the parent method to store the selected value.
+	 * 
+	 * @since x.x
+	 *
+	 * @param WPBDP_Form_Field_Type $field
+	 * @param int|string $post_id
+	 * @param string $value
+	 * 
+	 * @return void
+	 */
 	public function store_field_value( &$field, $post_id, $value ) {
 		$this->store_field_selected_value( $field, $post_id, $value );
 

--- a/includes/fields/class-fieldtypes-radiobutton.php
+++ b/includes/fields/class-fieldtypes-radiobutton.php
@@ -52,8 +52,10 @@ class WPBDP_FieldTypes_RadioButton extends WPBDP_Form_Field_Type {
 			return $html;
 		}
 
-		$html = '';
-		$i    = 1;
+		$html     = '';
+		$i        = 1;
+		$selected = $this->get_field_selected_value( $field );
+
 		foreach ( $options as $option => $label ) {
 			$css_classes   = array();
 			$css_classes[] = 'wpbdp-inner-field-option';
@@ -64,12 +66,17 @@ class WPBDP_FieldTypes_RadioButton extends WPBDP_Form_Field_Type {
 			$css_classes[] = 'wpbdp-inner-radio-' . $i;
 			$css_classes[] = 'wpbdp-inner-radio-' . WPBDP_Form_Field_Type::normalize_name( $label );
 
+			$checked = '';
+
+			if ( $selected === $option || $value === $option ) {
+				$checked = 'checked="checked"';
+			}
+
 			$html .= sprintf(
-				'<div class="%1%s"><label for="wpbdp-field-%6$d-%5$s"><input id="wpbdp-field-%6$d-%5$s" type="radio" name="%2$s" value="%3$s" %4$s /> %5$s</label></div>',
+				'<div class="%1$s"><label for="wpbdp-field-%5$d-%4$s"><input id="wpbdp-field-%5$d-%4$s" type="radio" name="%2$s" value="%4$s" %3$s /> %4$s</label></div>',
 				implode( ' ', $css_classes ),
 				'listingfields[' . $field->get_id() . ']',
-				$option,
-				$value == $option ? 'checked="checked"' : '',
+				$checked,
 				esc_attr( $label ),
 				$field->get_id()
 			);
@@ -77,6 +84,12 @@ class WPBDP_FieldTypes_RadioButton extends WPBDP_Form_Field_Type {
 		}
 
 		return $html;
+	}
+
+	public function store_field_value( &$field, $post_id, $value ) {
+		$this->store_field_selected_value( $field, $post_id, $value );
+
+		parent::store_field_value( $field, $post_id, $value );
 	}
 
 	public function get_supported_associations() {

--- a/includes/fields/class-fieldtypes-select.php
+++ b/includes/fields/class-fieldtypes-select.php
@@ -244,22 +244,26 @@ class WPBDP_FieldTypes_Select extends WPBDP_Form_Field_Type {
 	 */
 	private function add_options_to_field( $options, $value, $field ) {
 		$html = '';
+
+		$selected = $this->get_field_selected_value( $field );
+
 		foreach ( $options as $option => $label ) {
 			$option_data = array(
 				'label'      => $label,
-				'value'      => esc_attr( $option ),
 				'attributes' => array(),
 			);
 
-			if ( in_array( $option, $value ) ) {
+			if (
+				( ! empty( $selected ) && $option === $selected ) ||
+				in_array( $option, $value, true )
+			) {
 				$option_data['attributes']['selected'] = 'selected';
 			}
 
 			$option_data = apply_filters( 'wpbdp_form_field_select_option', $option_data, $field );
 
 			$html .= sprintf(
-				'<option value="%s" class="%s" %s>%s</option>',
-				esc_attr( $option_data['value'] ),
+				'<option value="%3$s" class="%1$s" %2$s>%3$s</option>',
 				esc_attr( 'wpbdp-inner-field-option wpbdp-inner-field-option-' . WPBDP_Form_Field_Type::normalize_name( $option_data['label'] ) ),
 				self::html_attributes( $option_data['attributes'], array( 'value', 'class' ) ),
 				esc_html( $option_data['label'] )
@@ -361,6 +365,8 @@ class WPBDP_FieldTypes_Select extends WPBDP_Form_Field_Type {
 		} elseif ( 'meta' == $field->get_association() ) {
 			$value = is_array( $value ) ? ( ! empty( $value ) ? $value[0] : '' ) : $value;
 		}
+
+		$this->store_field_selected_value( $field, $post_id, $value );
 
 		parent::store_field_value( $field, $post_id, $value );
 	}


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/260

This PR changes the DOM rendering for the multi-select and radio field types to use the label value in the value attribute.

This way we can store and render the translated values on the listing page.

It also saves the selected value of those fields as separate post meta so that we know which one is selected/checked no matter what translated value is stored.