### PR TITLE
Add placeholder option for required dropdowns

### DIFF
--- a/includes/fields/class-fieldtypes-select.php
+++ b/includes/fields/class-fieldtypes-select.php
@@ -237,11 +237,7 @@ class WPBDP_FieldTypes_Select extends WPBDP_Form_Field_Type {
 			return '<option value="">' . esc_html( $empty_option_label ) . '</option>';
 		}
 
-		if ( $show_choose_one ) {
-			return '<option value="">' . esc_html__( '-- Choose One --', 'business-directory-plugin' ) . '</option>';
-		}
-
-		return '';
+		return $show_choose_one ? '<option value="">' . esc_html__( '-- Choose One --', 'business-directory-plugin' ) . '</option>' : '';
 	}
 
 	/**

--- a/includes/fields/class-fieldtypes-select.php
+++ b/includes/fields/class-fieldtypes-select.php
@@ -222,19 +222,26 @@ class WPBDP_FieldTypes_Select extends WPBDP_Form_Field_Type {
 	 * @return string
 	 */
 	private function add_empty_option( $field ) {
-		$show_empty_option = $field->data( 'show_empty_option', null );
+		$show_empty_field_option = $field->data( 'show_empty_option', null );
+		$show_choose_one         = false;
 
-		if ( is_null( $show_empty_option ) ) {
-			$show_empty_option = ! $field->has_validator( 'required' );
+		if ( is_null( $show_empty_field_option ) ) {
+			$show_empty_field_option = ! $field->has_validator( 'required' );
+			$show_choose_one         = true;
 		}
 
-		$html = '';
-		if ( $show_empty_option ) {
+		if ( $show_empty_field_option ) {
 			$default_label      = __( '— None —', 'business-directory-plugin' );
 			$empty_option_label = $field->data( 'empty_option_label', $default_label );
-			$html              .= '<option value="">' . esc_html( $empty_option_label ) . '</option>';
+			
+			return '<option value="">' . esc_html( $empty_option_label ) . '</option>';
 		}
-		return $html;
+
+		if ( $show_choose_one ) {
+			return '<option value="">' . esc_html__( '-- Choose One --', 'business-directory-plugin' ) . '</option>';
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/294#issuecomment-2794976259

This PR adds a default empty option to the required dropdown fields that don't have a `show_empty_option` property to ensure that it doesn't render the default option on the category field or any other custom dropdowns that have the empty option disabled.