### PR TITLE
Check for missing fields before creating defaults

### DIFF
--- a/includes/form-fields.php
+++ b/includes/form-fields.php
@@ -465,6 +465,10 @@ if ( ! class_exists( 'WPBDP_FormFields' ) ) {
 		}
 
 		public function create_default_fields( $identifiers = array() ) {
+			if ( empty( $this->get_missing_required_fields() ) ) {
+				return;
+			}
+
 			$default_fields   = $this->get_default_fields();
 			$fields_to_create = $identifiers ? array_intersect_key( $default_fields, array_flip( $identifiers ) ) : $default_fields;
 


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/262

This PR adds a check in the `create_default_fields` method that first checks if there are any missing required fields before creating the default ones to avoid duplications.