### PR TITLE
Add early check for content

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -875,6 +875,10 @@ function wpbdp_get_term_name( $id_or_slug, $taxonomy = WPBDP_CATEGORY_TAX, $fiel
 }
 
 function wpbdp_has_shortcode( $content, $shortcode ) {
+	if ( empty( $content ) ) {
+		return false;
+	}
+
 	$check = has_shortcode( $content, $shortcode );
 
 	if ( ! $check ) {


### PR DESCRIPTION
fixes https://github.com/Strategy11/business-directory-premium/issues/311

This PR adds an early content check in the `wpbdp_has_shortcode` function to return early if `$content` is empty.