### PR TITLE
Fix null deprecated issue when no sale exists

### DIFF
--- a/includes/admin/helpers/class-sales-api.php
+++ b/includes/admin/helpers/class-sales-api.php
@@ -105,7 +105,9 @@ class WPBDP_Sales_API extends WPBDP_Modules_API {
 	 */
 	public static function get_best_sale_cta_link( $key, $utm_medium ) {
 		$link = self::get_best_sale_value( $key );
-		$link = self::add_missing_utm_params( $link, $utm_medium );
+		if ( is_string( $link ) ) {
+			$link = self::add_missing_utm_params( $link, $utm_medium );
+		}
 		return $link;
 	}
 


### PR DESCRIPTION
I noticed this popping up a lot in my error logs.

> PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/mikeletellier/Local Sites/dev-site/app/public/wp-content/plugins/business-directory-plugin/includes/admin/helpers/class-sales-api.php on line 130