### PR TITLE
Fix release workflow: split grunt tasks to avoid PHP dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Bump version and update assets
         run: |
           pnpm run build
-          pnpm exec grunt release:plugin:${{ inputs.version }}
+          pnpm exec grunt setversion:plugin:${{ inputs.version }}
+          pnpm exec grunt less:plugin
 
       - name: Update Tested up to
         if: inputs.tested_up_to != ''


### PR DESCRIPTION
## Summary
- Replace `grunt release:plugin:VERSION` with individual tasks:
  - `grunt setversion:plugin:VERSION` (version bump)
  - `grunt less:plugin` (LESS compilation)
- `pnpm run build` already handles webpack + uglify
- Avoids `makepot` (needs PHP) and `compress` (creates unnecessary ZIP)

Supersedes #507.

## Test plan
- [ ] Run Actions → Release with phase `prepare`
- [ ] Confirm release branch + PR created with version bumps + rebuilt assets