### PR TITLE
Set plugin-specific user agents on Business Directory requests

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -292,7 +292,8 @@ if ( ! class_exists( 'WPBDP_Admin' ) ) {
 			$response = wp_remote_post(
 				'https://feedback.strategy11.com/wp-json/frm/v2/entries',
 				array(
-					'body' => array(
+					'user-agent' => wpbdp_http_user_agent(),
+					'body'       => array(
 						'bd-firstname1' => $current_user->first_name,
 						'bd-email-1'    => $email,
 						'form_id'       => 'bd-plugin-course',

--- a/includes/admin/controllers/class-onboarding-wizard.php
+++ b/includes/admin/controllers/class-onboarding-wizard.php
@@ -270,7 +270,8 @@ final class WPBDP_Onboarding_Wizard {
 		wp_remote_post(
 			'https://feedback.strategy11.com/wp-json/frm/v2/entries',
 			array(
-				'body' => array(
+				'user-agent' => wpbdp_http_user_agent(),
+				'body'       => array(
 					'bd-firstname1' => $user->first_name,
 					'bd-email-1'    => $user->user_email,
 					'form_id'       => 'bd-plugin-course',

--- a/includes/admin/controllers/class-themes-admin.php
+++ b/includes/admin/controllers/class-themes-admin.php
@@ -420,8 +420,9 @@ class WPBDP_Themes_Admin {
 				WPBDP_Licensing::STORE_URL
 			),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout'    => 15,
+				'user-agent' => wpbdp_http_user_agent(),
+				'sslverify'  => false,
 			)
 		);
 
@@ -532,7 +533,10 @@ class WPBDP_Themes_Admin {
 	 * @return false|string|WP_Error File path on success, WP_Error on download failure, false if not a valid ZIP.
 	 */
 	private function download_theme_zip( $url ) {
+		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+		add_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10, 2 );
 		$tmpfile = download_url( $url );
+		remove_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10 );
 
 		if ( is_wp_error( $tmpfile ) ) {
 			return $tmpfile;

--- a/includes/admin/helpers/class-modules-api.php
+++ b/includes/admin/helpers/class-modules-api.php
@@ -89,14 +89,11 @@ class WPBDP_Modules_API {
 
 		$this->set_running();
 
-		// We need to know the version number to allow different downloads.
-		$agent = 'Business Directory/' . WPBDP_VERSION;
-
 		$response = wp_remote_get(
 			$url,
 			array(
 				'timeout'    => 25,
-				'user-agent' => $agent . '; ' . get_bloginfo( 'url' ),
+				'user-agent' => wpbdp_http_user_agent(),
 			)
 		);
 

--- a/includes/admin/upgrades/class-themes-updater.php
+++ b/includes/admin/upgrades/class-themes-updater.php
@@ -96,8 +96,9 @@ class WPBDP_Themes_Updater {
 		$response = wp_remote_get(
 			add_query_arg( $request, 'http://businessdirectoryplugin.com/' ),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout'    => 15,
+				'user-agent' => wpbdp_http_user_agent(),
+				'sslverify'  => false,
 			)
 		);
 
@@ -226,7 +227,10 @@ class WPBDP_Themes_Updater {
 			return new WP_Error( 'invalid_package_url', 'No package URL provided.' );
 		}
 
+		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+		add_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10, 2 );
 		$download_file = download_url( $url );
+		remove_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10 );
 		if ( is_wp_error( $download_file ) ) {
 			return new WP_Error( 'download_failed', 'Could not download theme package.', $download_file->get_error_message() );
 		}

--- a/includes/controllers/class-addons-controller.php
+++ b/includes/controllers/class-addons-controller.php
@@ -104,7 +104,10 @@ class WPBDP_Addons_Controller {
 		// Create the plugin upgrader with our custom skin.
 		require_once WPBDP_INC . 'models/class-installer-skin.php';
 		$installer = new Plugin_Upgrader( new WPBDP_Installer_Skin() );
+		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+		add_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10, 2 );
 		$installer->install( $download_url );
+		remove_filter( 'http_request_args', 'wpbdp_add_user_agent_to_business_directory_request', 10 );
 
 		// Flush the cache and return the newly installed plugin basename.
 		wp_cache_flush();

--- a/includes/gateways/stripe/helpers/classStrpConnectHelper.php
+++ b/includes/gateways/stripe/helpers/classStrpConnectHelper.php
@@ -95,8 +95,9 @@ class WPBDPStrpConnectHelper {
 		$timeout = 45; // (seconds) default timeout is 5. we want a bit more time to work with.
 		self::try_to_extend_server_timeout( $timeout );
 
-		$args     = compact( 'body', 'headers', 'timeout' );
-		$response = wp_remote_post( $url, $args );
+		$args               = compact( 'body', 'headers', 'timeout' );
+		$args['user-agent'] = wpbdp_http_user_agent();
+		$response           = wp_remote_post( $url, $args );
 
 		if ( ! self::validate_response( $response ) ) {
 			return 'Response from server is invalid';

--- a/includes/licensing.php
+++ b/includes/licensing.php
@@ -497,6 +497,8 @@ class WPBDP_Licensing {
 
 		curl_setopt( $ch, CURLOPT_URL, self::STORE_URL );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt
+		curl_setopt( $ch, CURLOPT_USERAGENT, wpbdp_http_user_agent() );
 
 		$r = curl_exec( $ch );
 
@@ -593,7 +595,7 @@ class WPBDP_Licensing {
 			$url,
 			array(
 				'timeout'    => 15,
-				'user-agent' => $this->user_agent_header(),
+				'user-agent' => wpbdp_http_user_agent(),
 				'sslverify'  => false,
 			)
 		);
@@ -1008,7 +1010,7 @@ class WPBDP_Licensing {
 			self::STORE_URL,
 			array(
 				'timeout'    => 15,
-				'user-agent' => $this->user_agent_header(),
+				'user-agent' => wpbdp_http_user_agent(),
 				'sslverify'  => false,
 				'body'       => $args,
 			)
@@ -1261,11 +1263,7 @@ class WPBDP_Licensing {
 	}
 
 	function user_agent_header() {
-		$user_agent  = 'Business Directory/' . WPBDP_VERSION;
-		$user_agent .= ' WordPress/' . get_bloginfo( 'version' );
-		$user_agent .= '; ' . get_bloginfo( 'url' );
-
-		return $user_agent;
+		return wpbdp_http_user_agent();
 	}
 
 	/**

--- a/includes/models/class-sitetracking.php
+++ b/includes/models/class-sitetracking.php
@@ -132,9 +132,10 @@ if ( ! class_exists( 'WPBDP_SiteTracking' ) ) {
 			wp_remote_post(
 				self::TRACKING_URL,
 				array(
-					'method'   => 'POST',
-					'blocking' => false,
-					'body'     => $data,
+					'method'     => 'POST',
+					'blocking'   => false,
+					'user-agent' => wpbdp_http_user_agent(),
+					'body'       => $data,
 				)
 			);
 		}
@@ -175,9 +176,10 @@ if ( ! class_exists( 'WPBDP_SiteTracking' ) ) {
 			wp_remote_post(
 				self::TRACKING_URL,
 				array(
-					'method'   => 'POST',
-					'blocking' => true,
-					'body'     => array(
+					'method'     => 'POST',
+					'blocking'   => true,
+					'user-agent' => wpbdp_http_user_agent(),
+					'body'       => array(
 						'uninstall' => '1',
 						'hash'      => $hash,
 						'reason'    => $reason,

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -713,6 +713,75 @@ function wpbdp_get_current_domain( $www = true, $prefix = '' ) {
 }
 
 /**
+ * Build a Business Directory user agent for outbound HTTP requests.
+ *
+ * @since x.x
+ *
+ * @param string $product Product name.
+ * @param string|null $version Product version.
+ *
+ * @return string
+ */
+function wpbdp_http_user_agent( $product = 'Business Directory', $version = null ) {
+	$product = (string) $product;
+
+	if ( '' === $product ) {
+		$product = 'Business Directory';
+	}
+
+	if ( null === $version && defined( 'WPBDP_VERSION' ) ) {
+		$version = WPBDP_VERSION;
+	}
+
+	$version    = (string) $version;
+	$user_agent = $product;
+	if ( '' !== $version ) {
+		$user_agent .= '/' . $version;
+	}
+
+	return $user_agent . '; ' . get_bloginfo( 'url' );
+}
+
+/**
+ * Check if a URL points to the Business Directory domain.
+ *
+ * @since x.x
+ *
+ * @param string $url The URL to check.
+ *
+ * @return bool
+ */
+function wpbdp_is_business_directory_request_url( $url ) {
+	$host = wp_parse_url( $url, PHP_URL_HOST );
+	if ( ! is_string( $host ) || '' === $host ) {
+		return false;
+	}
+
+	$host   = strtolower( $host );
+	$domain = 'businessdirectoryplugin.com';
+
+	return $domain === $host || substr( $host, -1 * ( strlen( $domain ) + 1 ) ) === '.' . $domain;
+}
+
+/**
+ * Add the Business Directory user agent to package downloads from our servers.
+ *
+ * @since x.x
+ *
+ * @param array  $args HTTP request args.
+ * @param string $url  Request URL.
+ *
+ * @return array
+ */
+function wpbdp_add_user_agent_to_business_directory_request( $args, $url ) {
+	if ( wpbdp_is_business_directory_request_url( $url ) ) {
+		$args['user-agent'] = wpbdp_http_user_agent();
+	}
+
+	return $args;
+}
+
+/**
  * Prepare an external link with utm parameters.
  *
  * @since 5.7.5


### PR DESCRIPTION
## Summary
- Add shared user-agent helper for Business Directory outbound requests.
- Apply it to licensing, updates, tracking, Stripe Connect, feedback forms, and package downloads.

## Test plan
- [ ] Trigger add-on list fetch, license check, and theme/add-on install; confirm requests use `Business Directory/<version>; <site-url>`.