### PR TITLE
Fix continue warning in migration 3.7

### DIFF
--- a/includes/admin/upgrades/migrations/migration-3_7.php
+++ b/includes/admin/upgrades/migrations/migration-3_7.php
@@ -169,7 +169,7 @@ class WPBDP__Migrations__3_7 extends WPBDP__Migration {
 
                             if ( ! $fee_info || ! term_exists( intval( $fee_info->category_id ), WPBDP_CATEGORY_TAX ) ) {
                                 $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}wpbdp_payments WHERE id = %d", $t['id'] ) );
-                                continue;
+                                continue 2;
                             }
 
                             $fee_info->fee = unserialize( $fee_info->fee );


### PR DESCRIPTION
Fixes Strategy11/business-directory-premium#358

Replace continue with continue 2 in the 3.7 payment migration so PHP 7.3+ no longer logs warnings when invalid renewal payments are skipped.