### PR TITLE
Fix Word Count Validator fatal on Post Tags

### DIFF
--- a/includes/models/form-fields-validation.php
+++ b/includes/models/form-fields-validation.php
@@ -261,6 +261,13 @@ if ( ! class_exists( 'WPBDP_FieldValidation' ) ) {
 				return;
 			}
 
+			// Tag-associated textfields convert comma-separated input to an array.
+			if ( is_array( $value ) ) {
+				$value = implode( ' ', $value );
+			}
+
+			$value = (string) $value;
+
 			$no_html_text = preg_replace( '/(<[^>]+>)/i', '', $value );
 			$input_array  = preg_split( '/[\s,]+/', $no_html_text );
 


### PR DESCRIPTION
Fixes Strategy11/business-directory-premium#361
Word Count Validator now normalizes array tag values before counting, so submit listing validation no longer fatals on Post Tags textfields.