### PR TITLE
Fix ZIP Code label in excerpt when street address is empty

### DIFF
--- a/includes/helpers/class-field-display-list.php
+++ b/includes/helpers/class-field-display-list.php
@@ -269,7 +269,18 @@ class WPBDP_Field_Display_List implements IteratorAggregate {
 		);
 
 		if ( ! $field ) {
-			return WPBDP_Form_Field_Type::field_label_display_wrapper( __( 'Address', 'business-directory-plugin' ), $atts );
+			$fallback = $this->get_address_label_fallback_item();
+			if ( ! $fallback ) {
+				return WPBDP_Form_Field_Type::field_label_display_wrapper( __( 'Address', 'business-directory-plugin' ), $atts );
+			}
+
+			if ( $fallback->field->has_display_flag( 'nolabel' ) ) {
+				return '';
+			}
+
+			$atts['field'] = $fallback->field;
+
+			return WPBDP_Form_Field_Type::field_label_display_wrapper( $fallback->label, $atts );
 		}
 
 		if ( $field->has_display_flag( 'nolabel' ) ) {
@@ -279,6 +290,33 @@ class WPBDP_Field_Display_List implements IteratorAggregate {
 		$atts['field'] = $field;
 
 		return WPBDP_Form_Field_Type::field_label_display_wrapper( $this->t_address->label, $atts );
+	}
+
+	/**
+	 * Find the first address-component field with a value when street Address is missing.
+	 *
+	 * @since x.x
+	 *
+	 * @return _WPBDP_Lightweight_Field_Display_Item|null
+	 */
+	private function get_address_label_fallback_item() {
+		foreach ( array( 'address2', 'city', 'state', 'country', 'zip' ) as $tag ) {
+			$item = $this->{'t_' . $tag};
+			if ( empty( $item->field ) ) {
+				continue;
+			}
+
+			$value = $item->value;
+			if ( is_array( $value ) ) {
+				$value = $value['zip'] ?? '';
+			}
+
+			if ( '' !== trim( (string) $value ) ) {
+				return $item;
+			}
+		}
+
+		return null;
 	}
 
 	public function helper__author() {

--- a/templates/excerpt_content.tpl.php
+++ b/templates/excerpt_content.tpl.php
@@ -5,15 +5,20 @@
 <div class="listing-details<?php echo esc_attr( $images->thumbnail ? '' : ' wpbdp-no-thumb' ); ?>">
 	<?php foreach ( $fields->not( 'social' ) as $field ) : ?>
 		<?php
-		$address = array( 'address', 'address2', 'city', 'state', 'country', 'zip' );
-		if ( in_array( $field->tag, $address ) ) :
-			if ( empty( $skip_address ) && $field->html ) :
-				$skip_address = $address;
-				?>
+		$address    = array( 'address', 'address2', 'city', 'state', 'country', 'zip' );
+		$has_street = ! empty( $fields->t_address->value );
+		if ( in_array( $field->tag, $address, true ) ) :
+			if ( $has_street ) :
+				if ( empty( $skip_address ) && $field->html ) :
+					$skip_address = $address;
+					?>
 		<div class="address-info wpbdp-field-display wpbdp-field wpbdp-field-value">
 				<?php echo wp_kses_post( $fields->_h_address_label ); ?>
 			<div><?php echo wp_kses_post( $fields->_h_address ); ?></div>
 		</div>
+				<?php endif; ?>
+			<?php elseif ( $field->html ) : ?>
+			<?php echo $field->html; // phpcs:ignore WordPress.Security.EscapeOutput ?>
 			<?php endif; ?>
 		<?php else : ?>
 			<?php echo $field->html; // phpcs:ignore WordPress.Security.EscapeOutput ?>


### PR DESCRIPTION
Fixes Strategy11/business-directory-premium#273
Excerpt view now groups address fields only when street Address has a value, so zip-only listings show the ZIP Code label instead of Address.