### PR TITLE
Fix checkbox and multiselect search substring matches

### DIFF
--- a/includes/fields/class-fieldtypes-checkbox.php
+++ b/includes/fields/class-fieldtypes-checkbox.php
@@ -283,7 +283,7 @@ class WPBDP_FieldTypes_Checkbox extends WPBDP_Form_Field_Type {
 			'_wpbdp[fields][' . $field->get_id() . ']'
 		);
 
-		$pattern             = '(' . implode( '|', $query ) . '){1}([tab]{0,1})';
+		$pattern             = '(^|\t)(' . implode( '|', $query ) . ')(\t|$)';
 		$search_res['where'] = $wpdb->prepare( "{$alias}.meta_value REGEXP %s", $pattern );
 
 		return $search_res;

--- a/includes/fields/class-fieldtypes-select.php
+++ b/includes/fields/class-fieldtypes-select.php
@@ -466,7 +466,7 @@ class WPBDP_FieldTypes_Select extends WPBDP_Form_Field_Type {
 			'_wpbdp[fields][' . $field->get_id() . ']'
 		);
 
-		$pattern             = '(' . implode( '|', $query ) . '){1}([tab]{0,1})';
+		$pattern             = '(^|\t)(' . implode( '|', $query ) . ')(\t|$)';
 		$search_res['where'] = $wpdb->prepare( "{$alias}.meta_value REGEXP %s", $pattern );
 
 		return $search_res;


### PR DESCRIPTION
Fixes Strategy11/business-directory-premium#65
Anchor advanced search REGEXP to tab-delimited tokens for checkbox and multiselect meta fields.